### PR TITLE
Feature: Add API Endpoints & Documentation

### DIFF
--- a/app/Console/Commands/RefreshPreprodDemo.php
+++ b/app/Console/Commands/RefreshPreprodDemo.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class RefreshPreprodDemo extends Command
+{
+  protected $signature = 'preprod:refresh-demo';
+  protected $description = 'Drop and reseed the database for the preprod demo environment.';
+
+  public function handle(): int
+  {
+    if (! app()->environment('preprod')) {
+      $this->error('This command is only allowed in the preprod environment.');
+      return self::FAILURE;
+    }
+
+    $this->info('Refreshing preprod database (migrate:fresh --seed)...');
+
+    Artisan::call('migrate:fresh', [
+      '--seed'  => true,
+      '--force' => true,
+    ]);
+
+    $this->line(Artisan::output());
+
+    $this->info('Preprod database refresh complete.');
+    return self::SUCCESS;
+  }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -12,7 +12,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule): void
     {
-        // $schedule->command('inspire')->hourly();
+      $schedule->command('preprod:refresh-demo')
+        ->dailyAt('00:00')
+        ->environments(['preprod']);
     }
 
     /**

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -1,76 +1,219 @@
 <?php
 
-  namespace App\Http\Controllers;
+namespace App\Http\Controllers;
 
-  use App\Models\Event;
-  use App\Http\Requests\StoreEventRequest;
-  use App\Http\Requests\UpdateEventRequest;
-  use Illuminate\Http\Request;
-  use Laravel\Jetstream\Jetstream;
+use App\Models\Event;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Jetstream\Jetstream;
 
-  class EventController extends Controller
+class EventController extends Controller
+{
+  /**
+   * List public, discoverable events.
+   *
+   * Returns upcoming public events along with their associated Cardano policy IDs.
+   * Clients can use this to find events that a connected wallet might qualify for.
+   *
+   * @group Public API
+   * @unauthenticated
+   *
+   * @queryParam policy_hashes[] string[] Optional. One or more Cardano policy IDs to filter by.
+   *                                      Only events that accept at least one of these policies
+   *                                      will be returned.
+   *                                      Example: policy_hashes[]=a0028f35...&policy_hashes[]=40fa2aa6...
+   *
+   * @response 200 scenario="success" {
+   *   "data": [
+   *     {
+   *       "uuid": "8f5fa03d-02c6-49f1-985f-d71544de8919",
+   *       "name": "Hydra Launch Party",
+   *       "description": "An exclusive Hydra-based launch event with live demos.",
+   *       "location": "Las Vegas Convention Center",
+   *       "date": "2025-01-24",
+   *       "start": "2025-01-24T18:00:00Z",
+   *       "end": "2025-01-24T21:00:00Z",
+   *       "policies": [
+   *         {
+   *           "hash": "a0028f35d4c7b4f2f0b1d6a0e4c3a9f6d0b0cafe",
+   *           "name": "HOSKY Token"
+   *         },
+   *         {
+   *           "hash": "40fa2aa65d983e1375f1a7c61ba57c0f0f5b9abc",
+   *           "name": "Clay Nation"
+   *         }
+   *       ],
+   *       "policy_hashes": [
+   *         "a0028f35d4c7b4f2f0b1d6a0e4c3a9f6d0b0cafe",
+   *         "40fa2aa65d983e1375f1a7c61ba57c0f0f5b9abc"
+   *       ]
+   *     }
+   *   ]
+   * }
+   *
+   * @responseField data[].uuid string The event UUID used in app links.
+   * @responseField data[].name string The display name of the event.
+   * @responseField data[].description string|null A short description of the event.
+   * @responseField data[].location string|null The event venue or location.
+   * @responseField data[].date string|null Event date in Y-m-d format.
+   * @responseField data[].start string|null ISO8601 start datetime.
+   * @responseField data[].end string|null ISO8601 end datetime.
+   * @responseField data[].policies[].hash string Cardano policy ID accepted for this event.
+   * @responseField data[].policies[].name string Human-readable label for the policy.
+   * @responseField data[].policy_hashes string[] Convenience array of all policy hashes for this event.
+   */
+  public function index(Request $request): JsonResponse
   {
-    /**
-     * Display a listing of the resource.
-     */
-    public function index()
-    {
-      //
+
+
+    $policyHashes = $request->input('policy_hashes', []);
+
+    if (is_array($policyHashes)) {
+      $policyHashes = array_values(array_filter($policyHashes));
+      sort($policyHashes); // order-independent
+    } else {
+      $policyHashes = [$policyHashes];
     }
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-      //
-    }
+    $cacheKey = $this->buildCacheKey($policyHashes);
 
-    /**
-     * Store a newly created resource in storage.
-     */
-    public function store(StoreEventRequest $request)
-    {
-      //
-    }
+    $data = Cache::remember($cacheKey, now()->addMinutes(5), function () use ($policyHashes) {
+      $now = Carbon::now();
 
-    /**
-     * Display the specified resource.
-     */
-    public function show(Request $request, string $eventUUID)
-    {
-      $event = Event::where('uuid', $eventUUID)
-                    ->with([
-                      'policies',
-                      'team'
-                    ])
-                    ->firstOrFail();
+      $query = Event::query()
+        ->where('is_public', true)
+        ->where(function ($q) use ($now) {
+          // Upcoming or currently-running: not ended yet
+          $q->whereNull('end_date_time')
+            ->orWhere('end_date_time', '>=', $now);
+        })
+        ->with([
+          'policies:id,hash,name',
+        ])
+        ->orderBy('start_date_time');
 
-      return Jetstream::inertia()
-                      ->render($request, 'Event/Show', compact('event'));
-    }
+      if (!empty($policyHashes) && is_array($policyHashes)) {
+        $query->whereHas('policies', function ($q) use ($policyHashes) {
+          $q->whereIn('hash', $policyHashes);
+        });
+      }
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Event $event)
-    {
-      //
-    }
+      $events = $query->get();
 
-    /**
-     * Update the specified resource in storage.
-     */
-    public function update(UpdateEventRequest $request, Event $event)
-    {
-      //
-    }
+      return $events->map(function (Event $event) {
+        return [
+          'uuid' => $event->uuid,
+          'name' => $event->name,
+          'description' => $event->description,
+          'location' => $event->location,
+          'date' => $event->event_date?->toDateString(),
+          'start' => $event->start_date_time?->toIso8601String(),
+          'end' => $event->end_date_time?->toIso8601String(),
+          'policies' => $event->policies->map(fn($policy) => [
+            'hash' => $policy->hash,
+            'name' => $policy->name,
+          ])->values(),
+          'policy_hashes' => $event->policies->pluck('hash')->values(),
+        ];
+      })->toArray();
+    });
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Event $event)
-    {
-      //
-    }
+
+    return response()->json([
+      'data' => $data,
+    ]);
   }
+
+  /**
+   * Discover public events for a specific policy.
+   *
+   * Returns upcoming public events that accept the given Cardano policy ID.
+   * This is a convenience wrapper around the main discover endpoint with a single policy filter.
+   *
+   * @group Public API
+   * @unauthenticated
+   *
+   * @urlParam policyHash string required The Cardano policy ID to filter by.
+   *                                     Example: a0028f35d4c7b4f2f0b1d6a0e4c3a9f6d0b0cafe
+   *
+   * @response 200 scenario="success" {
+   *   "data": [
+   *     {
+   *       "uuid": "8f5fa03d-02c6-49f1-985f-d71544de8919",
+   *       "name": "Hydra Launch Party",
+   *       "description": "An exclusive Hydra-based launch event with live demos.",
+   *       "location": "Las Vegas Convention Center",
+   *       "date": "2025-01-24",
+   *       "start": "2025-01-24T18:00:00Z",
+   *       "end": "2025-01-24T21:00:00Z",
+   *       "policies": [
+   *         {
+   *           "hash": "a0028f35d4c7b4f2f0b1d6a0e4c3a9f6d0b0cafe",
+   *           "name": "HOSKY Token"
+   *         }
+   *       ],
+   *       "policy_hashes": [
+   *         "a0028f35d4c7b4f2f0b1d6a0e4c3a9f6d0b0cafe"
+   *       ]
+   *     }
+   *   ]
+   * }
+   *
+   * @responseField data[].uuid string The event UUID used in app links.
+   * @responseField data[].name string The display name of the event.
+   * @responseField data[].description string|null A short description of the event.
+   * @responseField data[].location string|null The event venue or location.
+   * @responseField data[].date string|null Event date in Y-m-d format.
+   * @responseField data[].start string|null ISO8601 start datetime.
+   * @responseField data[].end string|null ISO8601 end datetime.
+   * @responseField data[].policies[].hash string Cardano policy ID accepted for this event.
+   * @responseField data[].policies[].name string Human-readable label for the policy.
+   * @responseField data[].policy_hashes string[] Convenience array of all policy hashes for this event.
+   */
+  public function byPolicy(Request $request, string $policyHash): JsonResponse
+  {
+    // Reuse the existing logic in index(), but pre-fill policy_hashes[]
+    $request->merge([
+      'policy_hashes' => [$policyHash],
+    ]);
+
+    return $this->index($request);
+  }
+
+  protected function buildCacheKey(array $policyHashes): string
+  {
+    if (empty($policyHashes)) {
+      return 'public_events:all';
+    }
+
+    return 'public_events:policies:'.md5(json_encode($policyHashes));
+  }
+
+  /**
+   * Display the specified event.
+   */
+  public function show(Request $request, string $eventUUID)
+  {
+    $event = Event::where('uuid', $eventUUID)
+      ->with([
+        'policies',
+        'team'
+      ])
+      ->firstOrFail();
+
+    return Jetstream::inertia()
+      ->render($request, 'Event/Show', compact('event'));
+  }
+
+  /**
+   * Connect your wallet and discover eligible events
+   */
+  public function discoverPage(Request $request)
+  {
+    // No props needed initially; the page will call the API itself
+    return Jetstream::inertia()
+      ->render($request, 'Event/Discover');
+  }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -1,219 +1,230 @@
 <?php
 
-  namespace App\Models;
+namespace App\Models;
 
-  use App\Traits\HasBackgroundImage;
-  use Illuminate\Database\Eloquent\Factories\HasFactory;
-  use Illuminate\Database\Eloquent\Model;
-  use Illuminate\Database\Eloquent\Relations\BelongsTo;
-  use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-  use Illuminate\Database\Eloquent\Relations\HasMany;
-  use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-  use Illuminate\Support\Carbon;
-  use Illuminate\Support\Collection;
-  use Laravel\Jetstream\HasProfilePhoto;
+use App\Traits\HasBackgroundImage;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Laravel\Jetstream\HasProfilePhoto;
 
-  class Event extends Model
+class Event extends Model
+{
+
+  use HasFactory;
+  use HasProfilePhoto;
+  use HasBackgroundImage;
+
+  protected $fillable = [
+    'uuid',
+    'team_id',
+    'user_id',
+    'name',
+    'nonce_valid_for_minutes',
+    'hodl_asset',
+    'start_date_time',
+    'end_date_time',
+    'location',
+    'event_start',
+    'event_end',
+    'event_date',
+    'image',
+  ];
+
+  protected $dates = [
+    'start_date_time',
+    'end_date_time',
+  ];
+
+  protected $hidden = [
+    'id',
+    'team_id',
+    'user_id',
+    'created_at',
+    'updated_at',
+    'checkins',
+    'checkouts'
+  ];
+
+  protected $appends = [
+    'profile_photo_url',
+    'bg_image_url',
+  ];
+
+  protected $casts = [
+    'event_date'      => 'date',
+    'start_date_time' => 'datetime',
+    'end_date_time'   => 'datetime',
+    'is_public'       => 'boolean',
+  ];
+
+  public function tickets(): HasMany
   {
+    return $this->hasMany(Ticket::class);
+  }
 
-    use HasFactory;
-    use HasProfilePhoto;
-    use HasBackgroundImage;
+  public function checkins(): HasManyThrough
+  {
+    return $this->hasManyThrough(Checkin::class, Ticket::class);
+  }
 
-    protected $fillable = [
-      'uuid',
-      'team_id',
-      'user_id',
-      'name',
-      'nonce_valid_for_minutes',
-      'hodl_asset',
-      'start_date_time',
-      'end_date_time',
-      'location',
-      'event_start',
-      'event_end',
-      'event_date',
-      'image',
-    ];
+  public function checkouts(): HasManyThrough
+  {
+    return $this->hasManyThrough(Checkout::class, Ticket::class);
+  }
 
-    protected $dates = [
-      'start_date_time',
-      'end_date_time',
-    ];
-
-    protected $hidden = [
-      'id',
-      'team_id',
-      'user_id',
-      'created_at',
-      'updated_at',
-      'checkins',
-      'checkouts'
-    ];
-
-    protected $appends = [
-      'profile_photo_url',
-      'bg_image_url',
-    ];
-
-    public function tickets(): HasMany
-    {
-      return $this->hasMany(Ticket::class);
-    }
-
-    public function checkins(): HasManyThrough
-    {
-      return $this->hasManyThrough(Checkin::class, Ticket::class);
-    }
-
-    public function checkouts(): HasManyThrough
-    {
-      return $this->hasManyThrough(Checkout::class, Ticket::class);
-    }
-
-    public function attendance(): Collection
-    {
-      return collect([
-        ...$this->checkins,
-        ...$this->checkouts
-      ]);
+  public function attendance(): Collection
+  {
+    return collect([
+      ...$this->checkins,
+      ...$this->checkouts
+    ]);
 //      return $this->checkins
 //        ->merge($this->checkouts);
-    }
-
-    public function policies(): BelongsToMany
-    {
-      return $this->belongsToMany(Policy::class);
-    }
-
-    public function team(): BelongsTo
-    {
-      return $this->belongsTo(Team::class);
-    }
-
-    public function user(): BelongsTo
-    {
-      return $this->belongsTo(User::class);
-    }
-
-    public function description()
-    {
-      $description = "";
-      if ($this->event_date) {
-        $description .= date('l, F jS, Y', strtotime($this->event_date));
-      }
-
-      if ($this->event_start && $this->event_end) {
-        $description .= " " . $this->event_start . " to " . $this->event_end . ".";
-      } elseif ($this->event_start) {
-        $description .= " " . $this->event_start;
-      } elseif ($this->event_end) {
-        $description .= " until " . $this->event_end;
-      }
-
-      if ($this->location) {
-        $description .= " " . $this->location;
-      }
-
-      return $description;
-
-    }
-
-    public function isTicketingActive(): bool
-    {
-      $now = Carbon::now();
-
-      if (!empty($this->start_date_time) && $now->isBefore($this->start_date_time)) {
-        return false;
-      }
-
-      if ($now->isAfter($this->end_date_time)) {
-        return false;
-      }
-
-      return true;
-    }
-
-    public function loadStats(): void
-    {
-      $stats = [
-        'tickets' => [
-          'count' => 0,
-          'byDate' => [],
-          'byPolicy' => []
-        ],
-        'attendance' => [
-          'unique_checkin' => Ticket::where('event_id', $this->id)
-                                    ->has('checkins')
-                                    ->count(),
-          'unique_checkout' => Ticket::where('event_id', $this->id)
-                                     ->has('checkouts')
-                                     ->count(),
-          'byUser' => [],
-          'byTime' => [
-            'labels' => [],
-            'datasets' => [
-              [
-                'label' => 'Attendance',
-                'data' => []
-              ]
-            ]
-          ]
-        ],
-      ];
-
-      $event_tickets = Ticket::where('event_id', $this->id)
-                             ->get();
-
-      foreach ($event_tickets as $ticket) {
-        $stats['tickets']['count']++;
-        $ticket_policy = $this->policies()
-                              ->where('id', $ticket->policy_id)
-                              ->firstOrFail();
-
-        @$stats['tickets']['byPolicy'][$ticket_policy->name]++;
-
-        $ticket_created = Carbon::parse($ticket->created_at)
-                                ->format('Y-m-d');
-
-        @$stats['tickets']['byDate'][$ticket_created]++;
-      }
-
-      foreach ($this->team
-                 ->allUsers() as $team_user) {
-        @$stats['attendance']['byUser'][$team_user->name]['checkin'] = $this->checkins()
-                                                                            ->where('user_id', $team_user->id)
-                                                                            ->count();
-        @$stats['attendance']['byUser'][$team_user->name]['checkout'] = $this->checkouts()
-                                                                             ->where('user_id', $team_user->id)
-                                                                             ->count();
-      }
-
-      $stats['tickets']['policy']['pieChart'] = [
-        'labels' => array_keys($stats['tickets']['byPolicy']),
-        'datasets' => [
-          [
-            'data' => array_values($stats['tickets']['byPolicy']),
-          ]
-        ]
-      ];
-
-      $this->checkins();
-      $this->checkouts();
-
-      $att = 0;
-      $attendance = $this->attendance()
-                         ->sortBy('created_at');
-      foreach ($attendance as $entry) {
-//        $stats['attendance']['byTime']['datasets'][0]['data'][] = $entry;
-
-        $att += $entry->direction === 'in' ? 1 : -1;
-
-        $stats['attendance']['byTime']['labels'][] = $entry->created_at->format('Y-m-d H:i');
-        $stats['attendance']['byTime']['datasets'][0]['data'][] = $att;
-      }
-
-      $this->stats = $stats;
-
-    }
   }
+
+  public function policies(): BelongsToMany
+  {
+    return $this->belongsToMany(Policy::class);
+  }
+
+  public function team(): BelongsTo
+  {
+    return $this->belongsTo(Team::class);
+  }
+
+  public function user(): BelongsTo
+  {
+    return $this->belongsTo(User::class);
+  }
+
+  public function description()
+  {
+    $description = "";
+    if ($this->event_date) {
+      $description .= date('l, F jS, Y', strtotime($this->event_date));
+    }
+
+    if ($this->event_start && $this->event_end) {
+      $description .= " " . $this->event_start . " to " . $this->event_end . ".";
+    } elseif ($this->event_start) {
+      $description .= " " . $this->event_start;
+    } elseif ($this->event_end) {
+      $description .= " until " . $this->event_end;
+    }
+
+    if ($this->location) {
+      $description .= " " . $this->location;
+    }
+
+    return $description;
+
+  }
+
+  public function isTicketingActive(): bool
+  {
+    $now = Carbon::now();
+
+    if (!empty($this->start_date_time) && $now->isBefore($this->start_date_time)) {
+      return false;
+    }
+
+    if ($now->isAfter($this->end_date_time)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public function loadStats(): void
+  {
+    $stats = [
+      'tickets' => [
+        'count' => 0,
+        'byDate' => [],
+        'byPolicy' => [],
+      ],
+      'attendance' => [
+        'unique_checkin' => Ticket::where('event_id', $this->id)
+          ->has('checkins')
+          ->count(),
+        'unique_checkout' => Ticket::where('event_id', $this->id)
+          ->has('checkouts')
+          ->count(),
+        'byUser' => [],
+        'byTime' => [
+          'labels' => [],
+          'datasets' => [
+            [
+              'label' => 'Attendance',
+              'data' => [],
+            ],
+          ],
+        ],
+      ],
+    ];
+
+    $event_tickets = Ticket::where('event_id', $this->id)->get();
+
+    foreach ($event_tickets as $ticket) {
+      $stats['tickets']['count']++;
+
+      $ticket_policy = $this->policies()
+        ->where('id', $ticket->policy_id)
+        ->first();
+
+      if (!$ticket_policy) {
+        \Log::warning('Ticket policy not attached to event', [
+          'event_id' => $this->id,
+          'event_uuid' => $this->uuid,
+          'ticket_id' => $ticket->id,
+          'policy_id' => $ticket->policy_id,
+        ]);
+        continue;
+      }
+
+      $policyName = $ticket_policy->name;
+      $stats['tickets']['byPolicy'][$policyName] = ($stats['tickets']['byPolicy'][$policyName] ?? 0) + 1;
+
+      $ticket_created = \Carbon\Carbon::parse($ticket->created_at)->format('Y-m-d');
+      $stats['tickets']['byDate'][$ticket_created] = ($stats['tickets']['byDate'][$ticket_created] ?? 0) + 1;
+    }
+
+    foreach ($this->team->allUsers() as $team_user) {
+      $checkinCount = $this->checkins()->where('user_id', $team_user->id)->count();
+      $checkoutCount = $this->checkouts()->where('user_id', $team_user->id)->count();
+
+      $stats['attendance']['byUser'][$team_user->name]['checkin'] = $checkinCount;
+      $stats['attendance']['byUser'][$team_user->name]['checkout'] = $checkoutCount;
+    }
+
+    $stats['tickets']['policy']['pieChart'] = [
+      'labels' => array_keys($stats['tickets']['byPolicy']),
+      'datasets' => [
+        [
+          'data' => array_values($stats['tickets']['byPolicy']),
+        ],
+      ],
+    ];
+
+    $this->checkins();
+    $this->checkouts();
+
+    $att = 0;
+    $attendance = $this->attendance()->sortBy('created_at');
+
+    foreach ($attendance as $entry) {
+      $att += $entry->direction === 'in' ? 1 : -1;
+
+      $stats['attendance']['byTime']['labels'][] = $entry->created_at->format('Y-m-d H:i');
+      $stats['attendance']['byTime']['datasets'][0]['data'][] = $att;
+    }
+
+    $this->stats = $stats;
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
+        "knuckleswtf/scribe": "^5.5",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39de03486f1c906f2b6ffc0bee1bfaa2",
+    "content-hash": "bf6cea2a8974693050fadf9c11f77453",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -7021,6 +7021,56 @@
     ],
     "packages-dev": [
         {
+            "name": "erusev/parsedown",
+            "version": "1.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/erusev/parsedown/issues",
+                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
+            },
+            "time": "2019-12-30T22:54:17+00:00"
+        },
+        {
             "name": "fakerphp/faker",
             "version": "v1.23.1",
             "source": {
@@ -7204,6 +7254,99 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "knuckleswtf/scribe",
+            "version": "5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/knuckleswtf/scribe.git",
+                "reference": "779f91aa01a18d271b2c8314d5c44635c7375dfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/knuckleswtf/scribe/zipball/779f91aa01a18d271b2c8314d5c44635c7375dfc",
+                "reference": "779f91aa01a18d271b2c8314d5c44635c7375dfc",
+                "shasum": ""
+            },
+            "require": {
+                "erusev/parsedown": "1.7.4",
+                "ext-fileinfo": "*",
+                "ext-json": "*",
+                "ext-pdo": "*",
+                "fakerphp/faker": "^1.23.1",
+                "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+                "league/flysystem": "^3.0",
+                "mpociot/reflection-docblock": "^1.0.1",
+                "nikic/php-parser": "^5.0",
+                "nunomaduro/collision": "^6.0|^7.0|^8.0",
+                "php": ">=8.1",
+                "ramsey/uuid": "^4.2.2",
+                "shalvah/clara": "3.3.0",
+                "shalvah/upgrader": ">=0.6.0",
+                "symfony/var-exporter": "^6.0|^7.0",
+                "symfony/yaml": "^6.0|^7.0"
+            },
+            "replace": {
+                "mpociot/laravel-apidoc-generator": "*"
+            },
+            "require-dev": {
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "laravel/legacy-factories": "^1.3.0",
+                "league/fractal": "^0.20",
+                "nikic/fast-route": "^1.3",
+                "orchestra/testbench": "^7.0|^8.0|^v9.10.0|^10.0",
+                "pestphp/pest": "^1.21|^2.0|^3.0",
+                "phpstan/phpstan": "^2.1.5",
+                "phpunit/phpunit": "^9.0|^10.0|^11.0",
+                "spatie/ray": "^1.41",
+                "symfony/css-selector": "^6.0|^7.0",
+                "symfony/dom-crawler": "^6.0|^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Knuckles\\Scribe\\ScribeServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Config/helpers.php"
+                ],
+                "psr-4": {
+                    "Knuckles\\Camel\\": "camel/",
+                    "Knuckles\\Scribe\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Shalvah"
+                }
+            ],
+            "description": "Generate API documentation for humans from your Laravel codebase.✍",
+            "homepage": "http://github.com/knuckleswtf/scribe",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/knuckleswtf/scribe/issues",
+                "source": "https://github.com/knuckleswtf/scribe/tree/5.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://patreon.com/shalvah",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-10-25T17:58:31+00:00"
         },
         {
             "name": "laravel/pint",
@@ -7416,6 +7559,59 @@
                 "source": "https://github.com/mockery/mockery"
             },
             "time": "2024-05-16T03:13:13+00:00"
+        },
+        {
+            "name": "mpociot/reflection-docblock",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mpociot/reflection-docblock.git",
+                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mpociot/reflection-docblock/zipball/c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
+                "reference": "c8b2e2b1f5cebbb06e2b5ccbf2958f2198867587",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mpociot": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/mpociot/reflection-docblock/issues",
+                "source": "https://github.com/mpociot/reflection-docblock/tree/master"
+            },
+            "time": "2016-06-20T20:53:12+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -9030,6 +9226,111 @@
             "time": "2023-02-07T11:34:05+00:00"
         },
         {
+            "name": "shalvah/clara",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shalvah/clara.git",
+                "reference": "6b30f389d71bfdd3f6e09f9b9537205ac7e118de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shalvah/clara/zipball/6b30f389d71bfdd3f6e09f9b9537205ac7e118de",
+                "reference": "6b30f389d71bfdd3f6e09f9b9537205ac7e118de",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "symfony/console": "^4.0|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "eloquent/phony-phpunit": "^7.0",
+                "phpunit/phpunit": "^9.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "helpers.php"
+                ],
+                "psr-4": {
+                    "Shalvah\\Clara\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "🔊 Simple, pretty, testable console output for CLI apps.",
+            "keywords": [
+                "cli",
+                "log",
+                "logging"
+            ],
+            "support": {
+                "issues": "https://github.com/shalvah/clara/issues",
+                "source": "https://github.com/shalvah/clara/tree/3.3.0"
+            },
+            "time": "2025-10-20T22:26:39+00:00"
+        },
+        {
+            "name": "shalvah/upgrader",
+            "version": "0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/shalvah/upgrader.git",
+                "reference": "d95ed17fe9f5e1ee7d47ad835595f1af080a867f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/shalvah/upgrader/zipball/d95ed17fe9f5e1ee7d47ad835595f1af080a867f",
+                "reference": "d95ed17fe9f5e1ee7d47ad835595f1af080a867f",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": ">=8.0",
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "dms/phpunit-arraysubset-asserts": "^0.2.0",
+                "pestphp/pest": "^1.21",
+                "phpstan/phpstan": "^1.0",
+                "spatie/ray": "^1.33"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Shalvah\\Upgrader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Shalvah",
+                    "email": "hello@shalvah.me"
+                }
+            ],
+            "description": "Create automatic upgrades for your package.",
+            "homepage": "http://github.com/shalvah/upgrader",
+            "keywords": [
+                "upgrade"
+            ],
+            "support": {
+                "issues": "https://github.com/shalvah/upgrader/issues",
+                "source": "https://github.com/shalvah/upgrader/tree/0.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://patreon.com/shalvah",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-02-20T11:51:46+00:00"
+        },
+        {
             "name": "spatie/backtrace",
             "version": "1.6.1",
             "source": {
@@ -9410,6 +9711,87 @@
             "time": "2024-06-12T15:01:18+00:00"
         },
         {
+            "name": "symfony/var-exporter",
+            "version": "v7.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
+                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-11T10:12:26+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v7.1.1",
             "source": {
@@ -9540,5 +9922,5 @@
         "php": "^8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -4,156 +4,164 @@ use Laravel\Fortify\Features;
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Fortify Guard
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify which authentication guard Fortify will use while
-    | authenticating users. This value should correspond with one of your
-    | guards that is already present in your "auth" configuration file.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Fortify Guard
+  |--------------------------------------------------------------------------
+  |
+  | Here you may specify which authentication guard Fortify will use while
+  | authenticating users. This value should correspond with one of your
+  | guards that is already present in your "auth" configuration file.
+  |
+  */
 
-    'guard' => 'web',
+  'guard' => 'web',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Fortify Password Broker
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify which password broker Fortify can use when a user
-    | is resetting their password. This configured value should match one
-    | of your password brokers setup in your "auth" configuration file.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Fortify Password Broker
+  |--------------------------------------------------------------------------
+  |
+  | Here you may specify which password broker Fortify can use when a user
+  | is resetting their password. This configured value should match one
+  | of your password brokers setup in your "auth" configuration file.
+  |
+  */
 
-    'passwords' => 'users',
+  'passwords' => 'users',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Username / Email
-    |--------------------------------------------------------------------------
-    |
-    | This value defines which model attribute should be considered as your
-    | application's "username" field. Typically, this might be the email
-    | address of the users but you are free to change this value here.
-    |
-    | Out of the box, Fortify expects forgot password and reset password
-    | requests to have a field named 'email'. If the application uses
-    | another name for the field you may define it below as needed.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Username / Email
+  |--------------------------------------------------------------------------
+  |
+  | This value defines which model attribute should be considered as your
+  | application's "username" field. Typically, this might be the email
+  | address of the users but you are free to change this value here.
+  |
+  | Out of the box, Fortify expects forgot password and reset password
+  | requests to have a field named 'email'. If the application uses
+  | another name for the field you may define it below as needed.
+  |
+  */
 
-    'username' => 'email',
+  'username' => 'email',
 
-    'email' => 'email',
+  'email' => 'email',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Lowercase Usernames
-    |--------------------------------------------------------------------------
-    |
-    | This value defines whether usernames should be lowercased before saving
-    | them in the database, as some database system string fields are case
-    | sensitive. You may disable this for your application if necessary.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Lowercase Usernames
+  |--------------------------------------------------------------------------
+  |
+  | This value defines whether usernames should be lowercased before saving
+  | them in the database, as some database system string fields are case
+  | sensitive. You may disable this for your application if necessary.
+  |
+  */
 
-    'lowercase_usernames' => true,
+  'lowercase_usernames' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Home Path
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure the path where users will get redirected during
-    | authentication or password reset when the operations are successful
-    | and the user is authenticated. You are free to change this value.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Home Path
+  |--------------------------------------------------------------------------
+  |
+  | Here you may configure the path where users will get redirected during
+  | authentication or password reset when the operations are successful
+  | and the user is authenticated. You are free to change this value.
+  |
+  */
 
-    'home' => '/dashboard',
+  'home' => '/dashboard',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Fortify Routes Prefix / Subdomain
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify which prefix Fortify will assign to all the routes
-    | that it registers with the application. If necessary, you may change
-    | subdomain under which all of the Fortify routes will be available.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Fortify Routes Prefix / Subdomain
+  |--------------------------------------------------------------------------
+  |
+  | Here you may specify which prefix Fortify will assign to all the routes
+  | that it registers with the application. If necessary, you may change
+  | subdomain under which all of the Fortify routes will be available.
+  |
+  */
 
-    'prefix' => '',
+  'prefix' => '',
 
-    'domain' => null,
+  'domain' => null,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Fortify Routes Middleware
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify which middleware Fortify will assign to the routes
-    | that it registers with the application. If necessary, you may change
-    | these middleware but typically this provided default is preferred.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Fortify Routes Middleware
+  |--------------------------------------------------------------------------
+  |
+  | Here you may specify which middleware Fortify will assign to the routes
+  | that it registers with the application. If necessary, you may change
+  | these middleware but typically this provided default is preferred.
+  |
+  */
 
-    'middleware' => ['web'],
+  'middleware' => ['web'],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Rate Limiting
-    |--------------------------------------------------------------------------
-    |
-    | By default, Fortify will throttle logins to five requests per minute for
-    | every email and IP address combination. However, if you would like to
-    | specify a custom rate limiter to call then you may specify it here.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Rate Limiting
+  |--------------------------------------------------------------------------
+  |
+  | By default, Fortify will throttle logins to five requests per minute for
+  | every email and IP address combination. However, if you would like to
+  | specify a custom rate limiter to call then you may specify it here.
+  |
+  */
 
-    'limiters' => [
-        'login' => 'login',
-        'two-factor' => 'two-factor',
-    ],
+  'limiters' => [
+    'login' => 'login',
+    'two-factor' => 'two-factor',
+  ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Register View Routes
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify if the routes returning views should be disabled as
-    | you may not need them when building your own application. This may be
-    | especially true if you're writing a custom single-page application.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Register View Routes
+  |--------------------------------------------------------------------------
+  |
+  | Here you may specify if the routes returning views should be disabled as
+  | you may not need them when building your own application. This may be
+  | especially true if you're writing a custom single-page application.
+  |
+  */
 
-    'views' => true,
+  'views' => true,
 
-    /*
-    |--------------------------------------------------------------------------
-    | Features
-    |--------------------------------------------------------------------------
-    |
-    | Some of the Fortify features are optional. You may disable the features
-    | by removing them from this array. You're free to only remove some of
-    | these features or you can even remove all of these if you need to.
-    |
-    */
+  /*
+  |--------------------------------------------------------------------------
+  | Features
+  |--------------------------------------------------------------------------
+  |
+  | Some of the Fortify features are optional. You may disable the features
+  | by removing them from this array. You're free to only remove some of
+  | these features or you can even remove all of these if you need to.
+  |
+  */
 
-    'features' => [
-        Features::registration(),
-        Features::resetPasswords(),
-        // Features::emailVerification(),
-        Features::updateProfileInformation(),
-        Features::updatePasswords(),
-        Features::twoFactorAuthentication([
-            'confirm' => true,
-            'confirmPassword' => true,
-            // 'window' => 0,
-        ]),
-    ],
+  'features' => [
+    env('ALLOW_REGISTRATION', false)
+      ? Features::registration()
+      : null,
+    env('ALLOW_PASSWORD_CHANGE', true)
+      ? Features::resetPasswords()
+      : null,
+    // Features::emailVerification(),
+    Features::updateProfileInformation(),
+    env('ALLOW_PASSWORD_CHANGE', true)
+      ? Features::updatePasswords()
+      : null,
+    env('ALLOW_PASSWORD_CHANGE', true)
+      ? Features::twoFactorAuthentication([
+      'confirm' => true,
+      'confirmPassword' => true,
+      // 'window' => 0,
+    ])
+      : null,
+  ],
 
 ];

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -1,0 +1,246 @@
+<?php
+
+use Knuckles\Scribe\Extracting\Strategies;
+use Knuckles\Scribe\Config\Defaults;
+use Knuckles\Scribe\Config\AuthIn;
+use function Knuckles\Scribe\Config\{removeStrategies, configureStrategy};
+
+// Only the most common configs are shown. See the https://scribe.knuckles.wtf/laravel/reference/config for all.
+
+return [
+  // The HTML <title> for the generated documentation.
+  'title' => config('app.name') . ' API Documentation',
+
+  // A short description of your API. Will be included in the docs webpage, Postman collection and OpenAPI spec.
+  'description' => '',
+
+  // Text to place in the "Introduction" section, right after the `description`. Markdown and HTML are supported.
+  'intro_text' => <<<INTRO
+        This documentation aims to provide all the information you need to work with our API.
+
+        <aside>As you scroll, you'll see code examples for working with the API in different programming languages in the dark area to the right (or as part of the content on mobile).
+        You can switch the language used with the tabs at the top right (or from the nav menu at the top left on mobile).</aside>
+    INTRO,
+
+  // The base URL displayed in the docs.
+  // If you're using `laravel` type, you can set this to a dynamic string, like '{{ config("app.tenant_url") }}' to get a dynamic base URL.
+  'base_url' => config("app.url"),
+
+  // Routes to include in the docs
+  'routes' => [
+    [
+      'match' => [
+        'prefixes' => [],
+        'domains' => ['*'],
+      ],
+      'include' => [
+        'api.events.discover',
+        'api.events.by-policy',
+      ],
+      'exclude' => [],
+    ],
+  ],
+
+  // The type of documentation output to generate.
+  // - "static" will generate a static HTMl page in the /public/docs folder,
+  // - "laravel" will generate the documentation as a Blade view, so you can add routing and authentication.
+  // - "external_static" and "external_laravel" do the same as above, but pass the OpenAPI spec as a URL to an external UI template
+  'type' => 'static',
+
+  // See https://scribe.knuckles.wtf/laravel/reference/config#theme for supported options
+  'theme' => 'default',
+
+  'static' => [
+    // HTML documentation, assets and Postman collection will be generated to this folder.
+    // Source Markdown will still be in resources/docs.
+    'output_path' => 'docs/api',
+  ],
+
+  'laravel' => [
+    // Whether to automatically create a docs route for you to view your generated docs. You can still set up routing manually.
+    'add_routes' => true,
+
+    // URL path to use for the docs endpoint (if `add_routes` is true).
+    // By default, `/docs` opens the HTML page, `/docs.postman` opens the Postman collection, and `/docs.openapi` the OpenAPI spec.
+    'docs_url' => '/docs',
+
+    // Directory within `public` in which to store CSS and JS assets.
+    // By default, assets are stored in `public/vendor/scribe`.
+    // If set, assets will be stored in `public/{{assets_directory}}`
+    'assets_directory' => null,
+
+    // Middleware to attach to the docs endpoint (if `add_routes` is true).
+    'middleware' => [],
+  ],
+
+  'external' => [
+    'html_attributes' => []
+  ],
+
+  'try_it_out' => [
+    // Add a Try It Out button to your endpoints so consumers can test endpoints right from their browser.
+    // Don't forget to enable CORS headers for your endpoints.
+    'enabled' => false,
+
+    // The base URL to use in the API tester. Leave as null to be the same as the displayed URL (`scribe.base_url`).
+    'base_url' => null,
+
+    // [Laravel Sanctum] Fetch a CSRF token before each request, and add it as an X-XSRF-TOKEN header.
+    'use_csrf' => false,
+
+    // The URL to fetch the CSRF token from (if `use_csrf` is true).
+    'csrf_url' => '/sanctum/csrf-cookie',
+  ],
+
+  // How is your API authenticated? This information will be used in the displayed docs, generated examples and response calls.
+  'auth' => [
+    // Set this to true if ANY endpoints in your API use authentication.
+    'enabled' => false,
+
+    // Set this to true if your API should be authenticated by default. If so, you must also set `enabled` (above) to true.
+    // You can then use @unauthenticated or @authenticated on individual endpoints to change their status from the default.
+    'default' => false,
+
+    // Where is the auth value meant to be sent in a request?
+    'in' => AuthIn::BEARER->value,
+
+    // The name of the auth parameter (e.g. token, key, apiKey) or header (e.g. Authorization, Api-Key).
+    'name' => 'key',
+
+    // The value of the parameter to be used by Scribe to authenticate response calls.
+    // This will NOT be included in the generated documentation. If empty, Scribe will use a random value.
+    'use_value' => env('SCRIBE_AUTH_KEY'),
+
+    // Placeholder your users will see for the auth parameter in the example requests.
+    // Set this to null if you want Scribe to use a random value as placeholder instead.
+    'placeholder' => '{YOUR_AUTH_KEY}',
+
+    // Any extra authentication-related info for your users. Markdown and HTML are supported.
+    'extra_info' => 'You can retrieve your token by visiting your dashboard and clicking <b>Generate API token</b>.',
+  ],
+
+  // Example requests for each endpoint will be shown in each of these languages.
+  // Supported options are: bash, javascript, php, python
+  // To add a language of your own, see https://scribe.knuckles.wtf/laravel/advanced/example-requests
+  // Note: does not work for `external` docs types
+  'example_languages' => [
+    'bash',
+    'javascript',
+  ],
+
+  // Generate a Postman collection (v2.1.0) in addition to HTML docs.
+  // For 'static' docs, the collection will be generated to public/docs/collection.json.
+  // For 'laravel' docs, it will be generated to storage/app/scribe/collection.json.
+  // Setting `laravel.add_routes` to true (above) will also add a route for the collection.
+  'postman' => [
+    'enabled' => true,
+
+    'overrides' => [
+      // 'info.version' => '2.0.0',
+    ],
+  ],
+
+  // Generate an OpenAPI spec (v3.0.1) in addition to docs webpage.
+  // For 'static' docs, the collection will be generated to public/docs/openapi.yaml.
+  // For 'laravel' docs, it will be generated to storage/app/scribe/openapi.yaml.
+  // Setting `laravel.add_routes` to true (above) will also add a route for the spec.
+  'openapi' => [
+    'enabled' => true,
+
+    'overrides' => [
+      // 'info.version' => '2.0.0',
+    ],
+
+    // Additional generators to use when generating the OpenAPI spec.
+    // Should extend `Knuckles\Scribe\Writing\OpenApiSpecGenerators\OpenApiGenerator`.
+    'generators' => [],
+  ],
+
+  'groups' => [
+    // Endpoints which don't have a @group will be placed in this default group.
+    'default' => 'Endpoints',
+
+    // By default, Scribe will sort groups alphabetically, and endpoints in the order their routes are defined.
+    // You can override this by listing the groups, subgroups and endpoints here in the order you want them.
+    // See https://scribe.knuckles.wtf/blog/laravel-v4#easier-sorting and https://scribe.knuckles.wtf/laravel/reference/config#order for details
+    // Note: does not work for `external` docs types
+    'order' => [],
+  ],
+
+  // Custom logo path. This will be used as the value of the src attribute for the <img> tag,
+  // so make sure it points to an accessible URL or path. Set to false to not use a logo.
+  // For example, if your logo is in public/img:
+  // - 'logo' => '../img/logo.png' // for `static` type (output folder is public/docs)
+  // - 'logo' => 'img/logo.png' // for `laravel` type
+  'logo' => false,
+
+  // Customize the "Last updated" value displayed in the docs by specifying tokens and formats.
+  // Examples:
+  // - {date:F j Y} => March 28, 2022
+  // - {git:short} => Short hash of the last Git commit
+  // Available tokens are `{date:<format>}` and `{git:<format>}`.
+  // The format you pass to `date` will be passed to PHP's `date()` function.
+  // The format you pass to `git` can be either "short" or "long".
+  // Note: does not work for `external` docs types
+  'last_updated' => 'Last updated: {date:F j, Y}',
+
+  'examples' => [
+    // Set this to any number to generate the same example values for parameters on each run,
+    'faker_seed' => 1234,
+
+    // With API resources and transformers, Scribe tries to generate example models to use in your API responses.
+    // By default, Scribe will try the model's factory, and if that fails, try fetching the first from the database.
+    // You can reorder or remove strategies here.
+    'models_source' => ['factoryCreate', 'factoryMake', 'databaseFirst'],
+  ],
+
+  // The strategies Scribe will use to extract information about your routes at each stage.
+  // Use configureStrategy() to specify settings for a strategy in the list.
+  // Use removeStrategies() to remove an included strategy.
+  'strategies' => [
+    'metadata' => [
+      ...Defaults::METADATA_STRATEGIES,
+    ],
+    'headers' => [
+      ...Defaults::HEADERS_STRATEGIES,
+      Strategies\StaticData::withSettings(data: [
+        'Content-Type' => 'application/json',
+        'Accept' => 'application/json',
+      ]),
+    ],
+    'urlParameters' => [
+      ...Defaults::URL_PARAMETERS_STRATEGIES,
+    ],
+    'queryParameters' => [
+      ...Defaults::QUERY_PARAMETERS_STRATEGIES,
+    ],
+    'bodyParameters' => [
+      ...Defaults::BODY_PARAMETERS_STRATEGIES,
+    ],
+    'responses' => configureStrategy(
+      Defaults::RESPONSES_STRATEGIES,
+      Strategies\Responses\ResponseCalls::withSettings(
+        only: ['GET *'],
+        // Recommended: disable debug mode in response calls to avoid error stack traces in responses
+        config: [
+          'app.debug' => false,
+        ]
+      )
+    ),
+    'responseFields' => [
+      ...Defaults::RESPONSE_FIELDS_STRATEGIES,
+    ]
+  ],
+
+  // For response calls, API resource responses and transformer responses,
+  // Scribe will try to start database transactions, so no changes are persisted to your database.
+  // Tell Scribe which connections should be transacted here. If you only use one db connection, you can leave this as is.
+  'database_connections_to_transact' => [
+//    config('database.default')
+  ],
+
+  'fractal' => [
+    // If you are using a custom serializer with league/fractal, you can specify it here.
+    'serializer' => null,
+  ],
+];

--- a/database/factories/EventFactory.php
+++ b/database/factories/EventFactory.php
@@ -2,22 +2,45 @@
 
 namespace Database\Factories;
 
+use App\Models\Event;
+use App\Models\Team;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Event>
+ * @extends Factory<Event>
  */
 class EventFactory extends Factory
 {
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
-    public function definition(): array
-    {
-        return [
-            //
-        ];
-    }
+  protected $model = Event::class;
+
+  public function definition(): array
+  {
+    $start = Carbon::now()->addDays($this->faker->numberBetween(1, 30))->setTime(
+      $this->faker->numberBetween(9, 18),
+      $this->faker->randomElement([0, 15, 30, 45])
+    );
+
+    $end = (clone $start)->addHours($this->faker->numberBetween(1, 4));
+
+    return [
+      'uuid'                    => (string) Str::uuid(),
+      'team_id'                 => Team::factory(),
+      'user_id'                 => User::factory(),
+      'name'                    => $this->faker->catchPhrase(),
+      'nonce_valid_for_minutes' => 15,
+      'hodl_asset'              => false,
+      'start_date_time'         => $start,
+      'end_date_time'           => $end,
+      'location'                => $this->faker->city(),
+      'event_start'             => $start->format('H:i'),
+      'event_end'               => $end->format('H:i'),
+      'event_date'              => $start->toDateString(),
+      'description'             => $this->faker->paragraph(3),
+      'bg_image_path'           => null,
+      'profile_photo_path'      => null,
+    ];
+  }
 }

--- a/database/factories/PolicyFactory.php
+++ b/database/factories/PolicyFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Policy;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Policy>
+ */
+class PolicyFactory extends Factory
+{
+  protected $model = Policy::class;
+
+  public function definition(): array
+  {
+    return [
+      'hash' => Str::random(56),
+      'name' => $this->faker->words(3, true) . ' Policy',
+      'team_id' => Team::factory(),
+      'user_id' => User::factory(),
+    ];
+  }
+}

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Ticket;
+use App\Models\Event;
+use App\Models\Policy;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ticket>
+ */
+class TicketFactory extends Factory
+{
+  protected $model = Ticket::class;
+
+  public function definition(): array
+  {
+    return [
+      'event_id' => Event::factory(),
+      'policy_id' => Policy::factory(),
+      'asset_id' => $this->faker->bothify(str_repeat('#', 40)), // adjust length as needed
+      'stake_key' => $this->faker->bothify(str_repeat('#', 40)),
+      'signature_nonce' => random_bytes(16), // binary(16)
+      'ticket_nonce' => random_bytes(16), // binary(16), nullable in schema but we'll fill it
+      'signature' => null,
+    ];
+  }
+}

--- a/database/migrations/2025_11_17_205744_add_is_public.php
+++ b/database/migrations/2025_11_17_205744_add_is_public.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+  /**
+   * Run the migrations.
+   */
+  public function up(): void
+  {
+    Schema::table('events', function (Blueprint $table) {
+      $table->boolean('is_public')
+        ->default(false)
+        ->after('profile_photo_path');
+
+      $table->index('is_public');
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   */
+  public function down(): void
+  {
+    Schema::table('events', function (Blueprint $table) {
+      $table->dropIndex(['is_public']);
+      $table->dropColumn('is_public');
+    });
+  }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,21 +2,16 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    /**
-     * Seed the application's database.
-     */
-    public function run(): void
-    {
-        // \App\Models\User::factory(10)->create();
+  public function run(): void
+  {
+    // Any global seeding goes here, e.g. default roles/permissions/user, etc.
 
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+    if (app()->environment('local')) {
+      $this->call(DemoEventSeeder::class);
     }
+  }
 }

--- a/database/seeders/DemoEventSeeder.php
+++ b/database/seeders/DemoEventSeeder.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use App\Models\Team;
+use App\Models\Event;
+use App\Models\Policy;
+use App\Models\Ticket;
+use App\Models\Checkin;
+use App\Models\Checkout;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Illuminate\Support\Carbon;
+
+class DemoEventSeeder extends Seeder
+{
+  public function run(): void
+  {
+    // 1) Create a demo user you can log in with
+    $user = User::query()->first() ?? User::factory()->create([
+      'name' => 'Demo Organizer',
+      'email' => 'demo@example.com',
+      'password' => Hash::make('password'), // <- demo password
+    ]);
+
+    // 2) Create a team for that user (or reuse first team)
+    $team = Team::query()->first() ?? Team::factory()->create([
+      'user_id' => $user->id,
+      'name' => 'Demo Event Team',
+      'personal_team' => true,
+    ]);
+
+    // 3) Well-known Cardano policies we want to use in the demo
+    $knownPolicies = [
+      [
+        'name' => 'HOSKY Token',
+        'hash' => 'a0028f350aaabe0545fdcb56b039bfb08e4bb4d8c4d7c3c7d481c235',
+      ],
+      [
+        'name' => 'Clay Nation (NFT)',
+        'hash' => '40fa2aa67258b4ce7b5782f74831d46a84c59a0ff0c28262fab21728',
+      ],
+      [
+        'name' => 'SpaceBudz (NFT)',
+        'hash' => 'f0ff48bbb7bbe9d59a40f1ce90e9e9d0ff5002ec48f232b49ca0fb9a',
+      ],
+      [
+        'name' => 'World Mobile Token (WMT)',
+        'hash' => '1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e',
+      ],
+      [
+        'name' => 'CLAY (Clay Nation FT)',
+        'hash' => '38ad9dc3aec6a2f38e220142b9aa6ade63ebe71f65e7cc2b7d8a8535',
+      ],
+    ];
+
+    // 4) Seed (or re-use) those policies for this team/user
+    $policies = collect($knownPolicies)->map(function (array $p) use ($team, $user) {
+      return Policy::updateOrCreate(
+        [
+          'team_id' => $team->id,
+          'hash' => $p['hash'],
+        ],
+        [
+          'name' => $p['name'],
+          'user_id' => $user->id,
+        ]
+      );
+    });
+
+    // 4) Create some demo events for this team/user
+    $eventDefinitions = [
+      [
+        'name' => 'Hydra Launch Party',
+        'description' => 'An exclusive event showcasing the Hydra-powered ticketing system.',
+        'days_from' => 10,
+        'hours_long' => 3,
+        'location' => 'Las Vegas Convention Center',
+        'ticket_window' => 'future',   // ticketing not yet started
+      ],
+      [
+        'name' => 'Cardano Community Meetup',
+        'description' => 'Monthly meetup for Cardano builders and enthusiasts.',
+        'days_from' => 3,
+        'hours_long' => 2,
+        'location' => 'Phoenix Blockchain Hub',
+        'ticket_window' => 'current',  // ticketing currently open
+      ],
+      [
+        'name' => 'VIP Governance Summit',
+        'description' => 'Invite-only strategy session for governance and scaling.',
+        'days_from' => 21,
+        'hours_long' => 4,
+        'location' => 'Berlin Innovation Campus',
+        'ticket_window' => 'closed',   // ticketing already closed
+      ],
+    ];
+
+    $events = collect($eventDefinitions)->map(function (array $spec) use ($team, $user) {
+      $eventStart = Carbon::now()
+        ->addDays($spec['days_from'])
+        ->setTime(18, 0); // 6pm for all demo events
+
+      $eventEnd = (clone $eventStart)->addHours($spec['hours_long']);
+
+      $now = Carbon::now();
+      switch ($spec['ticket_window']) {
+        case 'future':
+          // Ticketing opens in the future (not yet active)
+          $ticketStart = $now->copy()->addDays(2)->setTime(9, 0);
+          $ticketEnd = $now->copy()->addDays(5)->setTime(21, 0);
+          break;
+
+        case 'closed':
+          // Ticketing already ended in the past
+          $ticketStart = $now->copy()->subDays(10)->setTime(9, 0);
+          $ticketEnd = $now->copy()->subDays(5)->setTime(21, 0);
+          break;
+
+        case 'current':
+        default:
+          // Ticketing currently open (now is between start and end)
+          $ticketStart = $now->copy()->subDays(1)->setTime(9, 0);
+          $ticketEnd = $now->copy()->addDays(2)->setTime(21, 0);
+          break;
+      }
+
+      return Event::factory()
+        ->for($team)
+        ->for($user)
+        ->create([
+          'name' => $spec['name'],
+          'description' => $spec['description'],
+          'location' => $spec['location'],
+          'start_date_time' => $ticketStart,
+          'end_date_time' => $ticketEnd,
+          'event_start' => $eventStart->format('H:i'),
+          'event_end' => $eventEnd->format('H:i'),
+          'event_date' => $eventStart->toDateString(),
+          'is_public' => true,
+        ]);
+    });
+
+    // 5) Attach policies to events via pivot
+    $events->each(function (Event $event) use ($policies) {
+      $event->policies()->sync(
+        $policies->random($policies->count() - 1)->pluck('id')->all()
+      );
+    });
+
+    // 6) Create tickets per event
+    $events->each(function (Event $event) use ($policies) {
+      if ($event->policies()->count() === 0) {
+        $event->policies()->attach(
+          $policies->random(2)->pluck('id')->all()
+        );
+        $event->refresh();
+      }
+
+      $eventPolicies = $event->policies;
+
+      // 10 tickets per event, spread across policies
+      Ticket::factory()
+        ->count(10)
+        ->for($event)
+        ->state(function () use ($eventPolicies) {
+          return [
+            'policy_id' => $eventPolicies->random()->id,
+          ];
+        })
+        ->create();
+    });
+
+    // 7) Create past events with simulated tickets & check-ins
+    $pastEventDefinitions = [
+      [
+        'name' => 'Hydra Dev Workshop (Past)',
+        'description' => 'Hands-on workshop that already happened.',
+        'days_ago' => 7,
+        'hours_long' => 3,
+        'location' => 'Berlin',
+      ],
+      [
+        'name' => 'Governance Roundtable (Past)',
+        'description' => 'Past governance roundtable with real attendance.',
+        'days_ago' => 30,
+        'hours_long' => 4,
+        'location' => 'Online',
+      ],
+    ];
+
+    $pastEvents = collect($pastEventDefinitions)->map(function (array $spec) use ($team, $user) {
+      $eventStart = Carbon::now()
+        ->subDays($spec['days_ago'])
+        ->setTime(16, 0);
+
+      $eventEnd = (clone $eventStart)->addHours($spec['hours_long']);
+
+      // Ticketing window entirely in the past
+      $ticketStart = (clone $eventStart)->subDays(2);
+      $ticketEnd = (clone $eventStart)->subHours(1);
+
+      return Event::factory()
+        ->for($team)
+        ->for($user)
+        ->create([
+          'name' => $spec['name'],
+          'description' => $spec['description'],
+          'location' => $spec['location'],
+          'start_date_time' => $ticketStart,
+          'end_date_time' => $ticketEnd,
+          'event_start' => $eventStart->format('H:i'),
+          'event_end' => $eventEnd->format('H:i'),
+          'event_date' => $eventStart->toDateString(),
+          'is_public' => true,
+        ]);
+    });
+
+    // Attach policies to past events
+    $pastEvents->each(function (Event $event) use ($policies) {
+      $event->policies()->sync(
+        $policies->random(2)->pluck('id')->all()
+      );
+    });
+
+    // Create tickets + check-ins/check-outs for past events
+    $pastEvents->each(function (Event $event) use ($policies, $user) {
+      $eventPolicies = $event->policies;
+
+      $tickets = Ticket::factory()
+        ->count(15)
+        ->for($event)
+        ->state(function () use ($eventPolicies) {
+          return [
+            'policy_id' => $eventPolicies->random()->id,
+          ];
+        })
+        ->create();
+
+      // ~70% of ticket holders check in, ~80% of those check out
+      foreach ($tickets as $ticket) {
+        if (rand(1, 100) <= 70) {
+          $checkinTime = $event->event_date
+            ->copy()
+            ->setTimeFromTimeString($event->event_start) // "16:00" → time on that date
+            ->addMinutes(rand(-30, 60));
+
+          $checkin = Checkin::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $user->id,
+            'created_at' => $checkinTime,
+            'updated_at' => $checkinTime,
+          ]);
+
+          if (rand(1, 100) <= 80) {
+            $checkoutTime = $checkinTime->copy()->addMinutes(rand(30, 180));
+
+            Checkout::create([
+              'ticket_id' => $ticket->id,
+              'user_id' => $user->id,
+              'created_at' => $checkoutTime,
+              'updated_at' => $checkoutTime,
+            ]);
+          }
+        }
+      }
+    });
+
+    $this->command?->info('Demo events, policies, and tickets seeded.');
+    $this->command?->info('Demo login: demo@example.com / password');
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
             - 'host.docker.internal:host-gateway'
         ports:
             - '${APP_PORT:-80}:80'
-            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
@@ -27,6 +26,23 @@ services:
             - meilisearch
             - mailpit
             - selenium
+    vite:
+      image: node:20
+      working_dir: /var/www/html
+      volumes:
+        - ./:/var/www/html
+      command: >
+        sh -c "if [ ! -d node_modules ]; then
+                 echo '>> node_modules not found, running npm install...';
+                 npm install;
+               fi &&
+               npm run dev -- --host 0.0.0.0 --port ${VITE_PORT:-5173}"
+      ports:
+        - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+      networks:
+        - sail
+      depends_on:
+        - gatekeeper.app
     mysql:
         image: 'mysql/mysql-server:8.0'
         ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "GateKeeper-1.5",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -1156,6 +1156,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001629",
                 "electron-to-chromium": "^1.4.796",
@@ -1249,6 +1250,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.3.tgz",
             "integrity": "sha512-qK1gkGSRYcJzqrrzdR6a+I0vQ4/R+SoODXyAjscQ/4mzuNzySaMCd+hyVxitSY1+L2fjPD1Gbn+ibNqRmwQeLw==",
+            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -2060,6 +2062,7 @@
             "version": "2.30.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
             "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+            "peer": true,
             "engines": {
                 "node": "*"
             }
@@ -2244,6 +2247,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
@@ -2787,6 +2791,7 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
             "integrity": "sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -2920,6 +2925,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
             "integrity": "sha512-XBmSKRLXLxiaPYamLv3/hnP/KXDai1NDexN0FpkTaZXTfycHvkRHoenpgl/fvuK/kPbB6xAgoyiryAhQNxYmAQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.38",
@@ -2984,6 +2990,7 @@
             "version": "3.4.29",
             "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.29.tgz",
             "integrity": "sha512-8QUYfRcYzNlYuzKPfge1UWC6nF9ym0lx7mpGVPJYNhddxEf3DD0+kU07NTL0sXuiT2HuJuKr/iEO8WvXvT0RSQ==",
+            "peer": true,
             "dependencies": {
                 "@vue/compiler-dom": "3.4.29",
                 "@vue/compiler-sfc": "3.4.29",

--- a/package.json
+++ b/package.json
@@ -7,14 +7,11 @@
     },
     "devDependencies": {
         "@inertiajs/vue3": "^1.0.0",
-        "@tailwindcss/forms": "^0.5.2",
-        "@tailwindcss/typography": "^0.5.2",
         "@vitejs/plugin-vue": "^4.5.0",
         "autoprefixer": "^10.4.7",
         "axios": "^1.6.4",
         "laravel-vite-plugin": "^1.0.0",
         "postcss": "^8.4.14",
-        "tailwindcss": "^3.1.0",
         "vite": "^5.0.0",
         "vue": "^3.2.31"
     },

--- a/resources/js/Components/AppHeader.vue
+++ b/resources/js/Components/AppHeader.vue
@@ -1,73 +1,103 @@
 <script setup>
-import { useTheme } from 'vuetify'
+import {useTheme} from 'vuetify'
 import ApplicationLogo from "@/Components/ApplicationLogo.vue";
 import {onMounted, ref} from "vue";
 
+import { router } from '@inertiajs/vue3'
+
+const logout = () => {
+  router.post(route('logout'))
+}
+
 defineProps({
-    canLogin: {
-        type: Boolean,
-    },
-    canRegister: {
-        type: Boolean,
-    }
+  canLogin: {
+    type: Boolean,
+  },
+  canRegister: {
+    type: Boolean,
+  }
 });
 
 const theme = useTheme()
 
 function toggleTheme() {
-    const theme_value = theme.global.current.value.dark ? 'light' : 'dark'
-    localStorage.setItem('gatekeeper:theme', theme_value);
-    theme.global.name.value = theme_value;
+  const theme_value = theme.global.current.value.dark ? 'light' : 'dark'
+  localStorage.setItem('gatekeeper:theme', theme_value);
+  theme.global.name.value = theme_value;
 }
 
 const localTheme = ref({
-    value: null
+  value: null
 });
 
 onMounted(() => {
-    localTheme.value = localStorage.getItem('gatekeeper:theme') ?? 'light';
-    theme.global.name.value = localTheme.value;
+  localTheme.value = localStorage.getItem('gatekeeper:theme') ?? 'light';
+  theme.global.name.value = localTheme.value;
 })
 </script>
 <style>
+.v-toolbar#app-bar {
+  color: white !important;
+}
 .v-toolbar-title .gatekeeper-logo {
-    max-height: 50px;
-    width: auto;
-    margin-right: 0.5em;
-    fill: rgba(var(--v-theme-on-surface), var(--v-high-emphasis-opacity))
+  max-height: 50px;
+  width: auto;
+  margin-right: 0.5em;
+  fill: white
 }
 
 .v-toolbar-title__placeholder {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .app-name {
-    font-family: "Open Sans", sans-serif;
-    font-weight: 600;
-    font-size: 24px;
+  font-family: "Open Sans", sans-serif;
+  font-weight: 600;
+  font-size: 24px;
 }
 </style>
 <template>
-    <v-toolbar class="d-flex flex-row justify-between" color="transparent">
-        <v-toolbar-title>
-            <ApplicationLogo></ApplicationLogo>
-            <span class="app-name">GateKeeper</span>
-        </v-toolbar-title>
-        <v-spacer></v-spacer>
-        <v-toolbar-items>
-            <v-btn @click="toggleTheme">
-                <v-icon :icon="theme.global.current.value.dark ? 'mdi-weather-sunny' : 'mdi-weather-night'" />
-            </v-btn>
-            <template v-if="canLogin">
-                <v-btn color="primary" :href="route('dashboard')" v-if="$page.props.auth.user">
-                    Dashboard
-                </v-btn>
-                <template v-else>
-                    <v-btn color="primary" :href="route('login')">Log In</v-btn>
-                    <v-btn color="secondary" v-if="canRegister" :href="route('register')">Register</v-btn>
-                </template>
-            </template>
-        </v-toolbar-items>
-    </v-toolbar>
+  <v-toolbar id="app-bar" class="d-flex flex-row justify-between" color="transparent">
+    <v-toolbar-title @click="$router.push('/')">
+      <ApplicationLogo></ApplicationLogo>
+      <span class="app-name">GateKeeper</span>
+    </v-toolbar-title>
+    <v-spacer></v-spacer>
+    <v-toolbar-items>
+      <v-btn @click="toggleTheme">
+        <v-icon
+          :icon="theme.global.current.value.dark ? 'mdi-weather-sunny' : 'mdi-weather-night'"/>
+      </v-btn>
+      <v-btn :href="route('home')">
+        <v-icon icon="mdi-home"/>
+      </v-btn>
+      <v-btn :href="route('events.discover')" prepend-icon="mdi-creation">
+        Discover Events
+      </v-btn>
+      <template v-if="canLogin">
+        <template v-if="$page.props.auth.user">
+          <v-btn color="primary" :href="route('dashboard')">
+            Dashboard
+          </v-btn>
+          <v-btn
+            color="secondary"
+            prepend-icon="mdi-logout"
+            @click="logout"
+          >
+            Logout
+          </v-btn>
+        </template>
+        <template v-else>
+          <v-btn
+            color="primary"
+            prepend-icon="mdi-login"
+            :href="route('login')">Staff Log In</v-btn>
+          <v-btn color="secondary" prepend-icon="mdi-account-plus" v-if="canRegister" :href="route('register')">
+            Register
+          </v-btn>
+        </template>
+      </template>
+    </v-toolbar-items>
+  </v-toolbar>
 </template>

--- a/resources/js/Components/Banner.vue
+++ b/resources/js/Components/Banner.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, watchEffect } from 'vue';
-import { usePage } from '@inertiajs/vue3';
+import {ref, watchEffect} from 'vue';
+import {usePage} from '@inertiajs/vue3';
 
 const page = usePage();
 const show = ref(true);
@@ -8,51 +8,14 @@ const style = ref('success');
 const message = ref('');
 
 watchEffect(async () => {
-    style.value = page.props.jetstream.flash?.bannerStyle || 'success';
-    message.value = page.props.jetstream.flash?.banner || '';
-    show.value = true;
+  style.value = page.props.jetstream.flash?.bannerStyle || 'success';
+  message.value = page.props.jetstream.flash?.banner || '';
+  show.value = true;
 });
 </script>
 
 <template>
-    <v-alert v-if="show && message" :type="style" closable class="my-8">
-        {{message}}
-    </v-alert>
-<!--    <div>
-        <div v-if="show && message" :class="{ 'bg-indigo-500': style == 'success', 'bg-red-700': style == 'danger' }">
-            <div class="max-w-screen-xl mx-auto py-2 px-3 sm:px-6 lg:px-8">
-                <div class="flex items-center justify-between flex-wrap">
-                    <div class="w-0 flex-1 flex items-center min-w-0">
-                        <span class="flex p-2 rounded-lg" :class="{ 'bg-indigo-600': style == 'success', 'bg-red-600': style == 'danger' }">
-                            <svg v-if="style == 'success'" class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                            </svg>
-
-                            <svg v-if="style == 'danger'" class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-                            </svg>
-                        </span>
-
-                        <p class="ms-3 font-medium text-sm text-white truncate">
-                            {{ message }}
-                        </p>
-                    </div>
-
-                    <div class="shrink-0 sm:ms-3">
-                        <button
-                            type="button"
-                            class="-me-1 flex p-2 rounded-md focus:outline-none sm:-me-2 transition"
-                            :class="{ 'hover:bg-indigo-600 focus:bg-indigo-600': style == 'success', 'hover:bg-red-600 focus:bg-red-600': style == 'danger' }"
-                            aria-label="Dismiss"
-                            @click.prevent="show = false"
-                        >
-                            <svg class="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>-->
+  <v-alert v-if="show && message" :type="style" closable class="my-8">
+    {{ message }}
+  </v-alert>
 </template>

--- a/resources/js/Components/NetworkNotice.vue
+++ b/resources/js/Components/NetworkNotice.vue
@@ -1,0 +1,19 @@
+<script setup>
+import {computed} from "vue";
+
+const appEnv = import.meta.env.VITE_APP_ENV || 'production'
+const isPreprod = computed(() => appEnv === 'preprod')
+</script>
+<template>
+  <v-system-bar window
+    v-if="isPreprod"
+    color="warning"
+    density="compact"
+    class="align-center">
+    <v-spacer/>
+    <p>This is a demo / pre-production instance of GateKeeper.
+      Any data you enter here may be reset automatically at
+      &nbsp;<b>00:00 UTC</b> &nbsp;each day.</p>
+    <v-spacer/>
+  </v-system-bar>
+</template>

--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -4,6 +4,7 @@ import {Head, Link, router} from '@inertiajs/vue3';
 import ApplicationMark from '@/Components/ApplicationMark.vue';
 import {useTheme} from "vuetify";
 import Banner from "@/Components/Banner.vue";
+import NetworkNotice from "@/Components/NetworkNotice.vue";
 
 defineProps({
   title: String,
@@ -66,121 +67,123 @@ footer a {
 <template>
   <Head :title="title"/>
   <v-app>
-    <v-toolbar class="d-flex flex-row" color="transparent">
-      <v-app-bar-nav-icon
-        @click.stop="showingNavigation = !showingNavigation"></v-app-bar-nav-icon>
-      <v-toolbar-title class="flex-0-1">
-        <Link :href="route('dashboard')">
-          <ApplicationMark/>
-        </Link>
-      </v-toolbar-title>
-      <v-toolbar-items class="flex-fill">
-        <v-btn :href="route('dashboard')"
-               :active="route().current('dashboard')">Dashboard
-        </v-btn>
-        <v-btn :href="route('manage-event.index')"
-               :active="$page.component.startsWith('ManageEvent')">Events
-        </v-btn>
-      </v-toolbar-items>
-      <v-spacer></v-spacer>
-      <v-toolbar-items>
-        <v-btn @click="toggleTheme">
-          <v-icon
-            :icon="theme.global.current.value.dark ? 'mdi-weather-sunny' : 'mdi-weather-night'"/>
-        </v-btn>
-        <v-menu v-if="$page.props.jetstream.hasTeamFeatures">
-          <template v-slot:activator="{ props }">
-            <v-btn color="secondary" v-bind="props"
-                   :active="route().current('teams.show', $page.props.auth.user.current_team)">
-              <template v-slot:prepend>
-                <v-avatar>
-                  <v-img
-                    :src="$page.props.auth.user.current_team.profile_photo_url"/>
-                </v-avatar>
-              </template>
-              {{ $page.props.auth.user.current_team.name }}
-            </v-btn>
-          </template>
-          <v-list>
-            <v-list-subheader>Manage Team</v-list-subheader>
-            <v-list-item
-              :href="route('teams.show', $page.props.auth.user.current_team)">
-              <v-list-item-title>Team Settings</v-list-item-title>
-            </v-list-item>
-            <v-list-item v-if="$page.props.jetstream.canCreateTeams"
-                         :href="route('teams.create')">
-              <v-list-item-title>Create New Team
-              </v-list-item-title>
-            </v-list-item>
-            <template
-              v-if="$page.props.auth.user.all_teams.length > 1">
-              <v-divider></v-divider>
-              <v-list-subheader>Switch Team</v-list-subheader>
-              <v-list-item
-                v-for="team in $page.props.auth.user.all_teams"
-                :key="team.id" @click="switchToTeam(team)">
-                <template v-slot:append
-                          v-if="team.id == $page.props.auth.user.current_team_id">
-                  <v-icon icon="mdi-check-circle-outline"/>
-                </template>
+    <NetworkNotice />
+
+    <v-main>
+      <v-toolbar class="d-flex flex-row" color="transparent">
+        <v-app-bar-nav-icon
+          @click.stop="showingNavigation = !showingNavigation"></v-app-bar-nav-icon>
+        <v-toolbar-title class="flex-0-1">
+          <Link :href="route('dashboard')">
+            <ApplicationMark/>
+          </Link>
+        </v-toolbar-title>
+        <v-toolbar-items class="flex-fill">
+          <v-btn :href="route('dashboard')"
+                 :active="route().current('dashboard')">Dashboard
+          </v-btn>
+          <v-btn :href="route('manage-event.index')"
+                 :active="$page.component.startsWith('ManageEvent')">Events
+          </v-btn>
+        </v-toolbar-items>
+        <v-spacer></v-spacer>
+        <v-toolbar-items>
+          <v-btn @click="toggleTheme">
+            <v-icon
+              :icon="theme.global.current.value.dark ? 'mdi-weather-sunny' : 'mdi-weather-night'"/>
+          </v-btn>
+          <v-menu v-if="$page.props.jetstream.hasTeamFeatures">
+            <template v-slot:activator="{ props }">
+              <v-btn color="secondary" v-bind="props"
+                     :active="route().current('teams.show', $page.props.auth.user.current_team)">
                 <template v-slot:prepend>
                   <v-avatar>
-                    <v-img :src="team.profile_photo_url"
-                           :alt="team.name"/>
+                    <v-img
+                      :src="$page.props.auth.user.current_team.profile_photo_url"/>
                   </v-avatar>
                 </template>
-                <v-list-item-title>{{
-                    team.name
-                  }}
+                {{ $page.props.auth.user.current_team.name }}
+              </v-btn>
+            </template>
+            <v-list>
+              <v-list-subheader>Manage Team</v-list-subheader>
+              <v-list-item
+                :href="route('teams.show', $page.props.auth.user.current_team)">
+                <v-list-item-title>Team Settings</v-list-item-title>
+              </v-list-item>
+              <v-list-item v-if="$page.props.jetstream.canCreateTeams"
+                           :href="route('teams.create')">
+                <v-list-item-title>Create New Team
                 </v-list-item-title>
               </v-list-item>
+              <template
+                v-if="$page.props.auth.user.all_teams.length > 1">
+                <v-divider></v-divider>
+                <v-list-subheader>Switch Team</v-list-subheader>
+                <v-list-item
+                  v-for="team in $page.props.auth.user.all_teams"
+                  :key="team.id" @click="switchToTeam(team)">
+                  <template v-slot:append
+                            v-if="team.id == $page.props.auth.user.current_team_id">
+                    <v-icon icon="mdi-check-circle-outline"/>
+                  </template>
+                  <template v-slot:prepend>
+                    <v-avatar>
+                      <v-img :src="team.profile_photo_url"
+                             :alt="team.name"/>
+                    </v-avatar>
+                  </template>
+                  <v-list-item-title>{{
+                      team.name
+                    }}
+                  </v-list-item-title>
+                </v-list-item>
+              </template>
+            </v-list>
+          </v-menu>
+          <v-menu>
+            <template v-slot:activator="{ props }">
+              <v-btn color="primary" v-bind="props"
+                     :active="route().current('profile.show') || route().current('api-tokens.index')">
+                <template v-slot:prepend
+                          v-if="$page.props.jetstream.managesProfilePhotos">
+                  <v-avatar>
+                    <v-img
+                      :src="$page.props.auth.user.profile_photo_url"
+                      :alt="$page.props.auth.user.name"/>
+                  </v-avatar>
+                </template>
+                {{ $page.props.auth.user.name }}
+              </v-btn>
             </template>
-          </v-list>
-        </v-menu>
-        <v-menu>
-          <template v-slot:activator="{ props }">
-            <v-btn color="primary" v-bind="props"
-                   :active="route().current('profile.show') || route().current('api-tokens.index')">
-              <template v-slot:prepend
-                        v-if="$page.props.jetstream.managesProfilePhotos">
-                <v-avatar>
-                  <v-img
-                    :src="$page.props.auth.user.profile_photo_url"
-                    :alt="$page.props.auth.user.name"/>
-                </v-avatar>
-              </template>
-              {{ $page.props.auth.user.name }}
-            </v-btn>
-          </template>
-          <v-list>
-            <v-list-subheader>Manage Account</v-list-subheader>
-            <v-list-item :href="route('profile.show')"
-                         :active="route().current('profile.show')">
-              <template v-slot:prepend>
-                <v-icon icon="mdi-account"/>
-              </template>
-              <v-list-item-title>Profile</v-list-item-title>
-            </v-list-item>
-            <v-list-item :href="route('api-tokens.index')"
-                         :active="route().current('api-tokens.index')"
-                         v-if="$page.props.jetstream.hasApiFeatures">
-              <template v-slot:prepend>
-                <v-icon icon="mdi-api"/>
-              </template>
-              <v-list-item-title>API Tokens</v-list-item-title>
-            </v-list-item>
-            <v-divider></v-divider>
-            <v-list-item @click="logout">
-              <template v-slot:prepend>
-                <v-icon icon="mdi-logout"/>
-              </template>
-              <v-list-item-title>Logout</v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
-      </v-toolbar-items>
-    </v-toolbar>
-    <v-main>
+            <v-list>
+              <v-list-subheader>Manage Account</v-list-subheader>
+              <v-list-item :href="route('profile.show')"
+                           :active="route().current('profile.show')">
+                <template v-slot:prepend>
+                  <v-icon icon="mdi-account"/>
+                </template>
+                <v-list-item-title>Profile</v-list-item-title>
+              </v-list-item>
+              <v-list-item :href="route('api-tokens.index')"
+                           :active="route().current('api-tokens.index')"
+                           v-if="$page.props.jetstream.hasApiFeatures">
+                <template v-slot:prepend>
+                  <v-icon icon="mdi-api"/>
+                </template>
+                <v-list-item-title>API Tokens</v-list-item-title>
+              </v-list-item>
+              <v-divider></v-divider>
+              <v-list-item @click="logout">
+                <template v-slot:prepend>
+                  <v-icon icon="mdi-logout"/>
+                </template>
+                <v-list-item-title>Logout</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-toolbar-items>
+      </v-toolbar>
       <v-container fluid>
         <header class="py-16 text-center">
           <slot name="header"></slot>

--- a/resources/js/Layouts/GuestLayout.vue
+++ b/resources/js/Layouts/GuestLayout.vue
@@ -1,7 +1,8 @@
 <script setup>
 import {onMounted, ref} from 'vue';
-import {Head, Link, router} from '@inertiajs/vue3';
+import {Head} from '@inertiajs/vue3';
 import {useTheme} from "vuetify";
+import NetworkNotice from "@/Components/NetworkNotice.vue";
 
 defineProps({
   title: String
@@ -23,6 +24,8 @@ onMounted(() => {
   localTheme.value = localStorage.getItem('gatekeeper:theme') ?? 'light';
   theme.global.name.value = localTheme.value;
 })
+
+
 </script>
 <style>
 
@@ -30,7 +33,7 @@ onMounted(() => {
 <template>
   <Head :title="title"></Head>
   <v-app>
-<!--    <v-toolbar class="d-flex flex-row" color="transparent"></v-toolbar>-->
+    <NetworkNotice />
     <v-main>
       <slot name="header"></slot>
       <slot></slot>

--- a/resources/js/Pages/Event/Discover.vue
+++ b/resources/js/Pages/Event/Discover.vue
@@ -1,0 +1,490 @@
+<script setup>
+import {Buffer} from "buffer";
+import {
+  Address,
+  Value,
+  ScriptHash,
+} from "@emurgo/cardano-serialization-lib-asmjs";
+import {onMounted, ref, reactive, computed} from "vue";
+import {useTheme} from "vuetify";
+import GuestLayout from "@/Layouts/GuestLayout.vue";
+import axios from "axios";
+import AppHeader from "@/Components/AppHeader.vue";
+
+defineProps({
+  canLogin: {
+    type: Boolean,
+  },
+  canRegister: {
+    type: Boolean,
+  }
+});
+
+const bg_image = 'url(https://picsum.photos/2048/1080)';
+
+const snackbar = reactive({
+  show: false,
+  message: "",
+  color: "info", // 'success' | 'warning' | 'error' | 'info'
+  timeout: 6000,
+});
+
+function showSnackbar(message, color = "info", timeout = 6000) {
+  snackbar.message = message;
+  snackbar.color = color;
+  snackbar.timeout = timeout;
+  snackbar.show = true;
+}
+
+const modal = ref({
+  connectWallet: false,
+});
+
+const cardano = ref({
+  hasCardano: ref(false),
+  loading: ref(true),
+  attempts: ref(10),
+  status: ref("loading"),
+  wallets: [],
+  connected: null,
+  connection: null,
+  hardware_mode: ref(false),
+  network_mode: null,
+});
+
+const allEvents = ref([]);
+const eventsLoading = ref(false);
+const walletPolicies = ref([]);
+
+const eligibleEvents = computed(() => {
+  if (!walletPolicies.value.length) {
+    return [];
+  }
+
+  return allEvents.value.filter((event) => {
+    const hashes = event.policy_hashes || [];
+    return hashes.some((hash) => walletPolicies.value.includes(hash));
+  });
+});
+
+const is_valid_wallet = (name) => {
+  if (name === "typhon" || window.cardano[name] === undefined) {
+    return false;
+  }
+
+  const wallet = window.cardano[name];
+
+  if (wallet.name === undefined || wallet.icon === undefined) {
+    return false;
+  }
+
+  if (name !== "typhoncip30" && wallet.name.toLowerCase() !== name.toLowerCase()) {
+    return false;
+  }
+
+  if (wallet.experimental && wallet.experimental.vespr_compat === true) {
+    return false;
+  }
+
+  if (wallet.name.includes("via VESPR")) {
+    return false;
+  }
+
+  return true;
+};
+
+const format_wallet_name = (wallet) => {
+  let formatted_name;
+
+  formatted_name = wallet.name.toLowerCase();
+  formatted_name = formatted_name.replace(" wallet", "");
+
+  return formatted_name;
+};
+
+const find_wallets = () => {
+  let loop = setInterval(() => {
+    if (cardano.value.attempts <= 0) {
+      if (cardano.value.wallets.length) {
+        cardano.value.status = "found";
+      } else {
+        cardano.value.status = "notfound";
+      }
+      clearInterval(loop);
+      cardano.value.loading = false;
+      return;
+    }
+
+    if (window.cardano !== undefined) {
+      cardano.value.hasCardano = true;
+
+      Object.keys(window.cardano).forEach((name) => {
+        if (!is_valid_wallet(name)) {
+          return;
+        }
+
+        const wallet = window.cardano[name];
+
+        if (!cardano.value.wallets.includes(wallet)) {
+          cardano.value.wallets.push(wallet);
+        }
+      });
+    }
+
+    cardano.value.attempts--;
+  }, 250);
+};
+
+const connect = async (wallet) => {
+  wallet.busy = true;
+  try {
+    cardano.value.connection = await wallet.enable();
+  } catch (e) {
+    wallet.busy = false;
+    return;
+  }
+  cardano.value.connected = wallet;
+  wallet.busy = false;
+  modal.value.connectWallet = false;
+  cardano.value.network_mode = await cardano.value.connection.getNetworkId();
+
+  await check_balance();
+};
+
+const disconnect = () => {
+  cardano.value.connected = null;
+  cardano.value.connection = null;
+  cardano.value.network_mode = null;
+  walletPolicies.value = [];
+  events.value = [];
+};
+
+const check_balance = async () => {
+  const wallet = cardano.value.connected;
+  const api = cardano.value.connection;
+  if (!wallet || !api) {
+    return;
+  }
+
+  wallet.busy = true;
+  wallet.balance = null;
+  wallet.assets = {};
+  walletPolicies.value = [];
+
+  try {
+    wallet.balance = Value.from_hex(await api.getBalance());
+  } catch (e) {
+    console.error(`Error getting wallet balance?`, e);
+    showSnackbar("Unable to read wallet balance.", "error");
+    wallet.busy = false;
+    return;
+  }
+
+  const multi = wallet.balance.multiasset();
+  if (!multi) {
+    wallet.busy = false;
+    return;
+  }
+
+  const policies = multi.keys();
+  const policySet = new Set();
+
+  for (let i = 0; i < policies.len(); i++) {
+    const policyHash = policies.get(i);
+    let policyHex;
+    try {
+      policyHex = toHex(policyHash.to_bytes());
+    } catch (e) {
+      console.error(`Unable to convert policy hash to hex`, e);
+      continue;
+    }
+    policySet.add(policyHex);
+  }
+
+  walletPolicies.value = Array.from(policySet);
+  wallet.busy = false;
+};
+
+const loadEvents = async () => {
+  eventsLoading.value = true;
+
+  try {
+    const response = await axios.get('/api/events/discover');
+    allEvents.value = response.data.data || [];
+  } catch (e) {
+    console.error('Error loading events', e);
+    showSnackbar(
+      e?.response?.data?.message ||
+      'There was an error while loading public events. Please try again.',
+      'error'
+    );
+  } finally {
+    eventsLoading.value = false;
+  }
+};
+
+const fromHex = (string) => {
+  return Buffer.from(string, "hex");
+};
+
+const toHex = (bytes) => {
+  return Buffer.from(bytes).toString("hex");
+};
+
+// --- Theme handling (same pattern as Show.vue) ---
+
+const theme = useTheme();
+
+const localTheme = ref({
+  value: null,
+});
+
+const toggleTheme = () => {
+  const theme_value = theme.global.current.value.dark ? "light" : "dark";
+  localStorage.setItem("gatekeeper:theme", theme_value);
+  theme.global.name.value = theme_value;
+};
+
+onMounted(async () => {
+  find_wallets();
+  localTheme.value = localStorage.getItem("gatekeeper:theme") ?? "light";
+  theme.global.name.value = localTheme.value;
+  await loadEvents();
+});
+</script>
+
+<template>
+  <GuestLayout title="Discover Events">
+    <template #header>
+      <header class="discover-header px-8">
+        <AppHeader />
+        <div class="py-16 d-flex align-center my-4">
+          <div>
+            <h1>Discover Events</h1>
+            <p class="mb-2">
+              Connect your Cardano wallet to see which public events you’re
+              eligible to attend based on the NFTs and tokens you hold.
+            </p>
+          </div>
+          <v-spacer/>
+          <template v-if="cardano.connected === null">
+            <v-btn
+              color="primary"
+              size="large"
+              :loading="cardano.loading"
+              v-if="cardano.status != 'notfound'"
+              @click="modal.connectWallet = true"
+            >
+              Connect Wallet
+            </v-btn>
+          </template>
+          <template v-else>
+            <div class="d-flex flex-column align-end">
+              <div>
+                <v-btn size="large" class="me-2"
+                       :loading="cardano.connected.busy">
+                  <v-avatar size="24" class="me-2">
+                    <v-img :src="cardano.connected.icon"/>
+                  </v-avatar>
+                  {{ format_wallet_name(cardano.connected) }} Connected
+                </v-btn>
+                <v-btn
+                  size="large"
+                  :loading="cardano.connected.busy"
+                  class="me-2"
+                  @click="check_balance().then(discoverEvents)"
+                >
+                  <v-icon icon="mdi-reload"/>
+                </v-btn>
+                <v-btn
+                  size="large"
+                  :loading="cardano.connected.busy"
+                  @click="disconnect"
+                >
+                  <v-icon icon="mdi-power"/>
+                </v-btn>
+              </div>
+              <small class="mt-2">
+                Found {{ walletPolicies.length }} unique policy
+                {{ walletPolicies.length === 1 ? "ID" : "IDs" }} in your wallet.
+              </small>
+            </div>
+          </template>
+        </div>
+      </header>
+    </template>
+
+    <v-container fluid>
+      <v-alert v-if="cardano.status == 'notfound'" type="error" class="mb-4">
+        <v-alert-title>No Cardano Wallet Found!</v-alert-title>
+        <p>
+          To discover eligible events, you’ll need a browser wallet that
+          supports the Cardano CIP-30 wallet standard. Please install a
+          compatible wallet and reload this page.
+        </p>
+      </v-alert>
+
+      <v-progress-linear
+        color="primary"
+        height="12"
+        indeterminate
+        v-if="cardano.loading || eventsLoading"
+        class="mb-4"
+      />
+
+      <template v-if="cardano.connected && !eventsLoading">
+        <template v-if="eligibleEvents.length">
+          <h2 class="mb-4">Events matching your wallet</h2>
+          <v-row>
+            <v-col
+              cols="12"
+              md="6"
+              lg="4"
+              v-for="event in eligibleEvents"
+              :key="event.uuid"
+            >
+              <v-card>
+                <v-card-title>{{ event.name }}</v-card-title>
+                <v-card-subtitle>
+                  <div v-if="event.location">
+                    <v-icon icon="mdi-map-marker" class="me-1"/>
+                    {{ event.location }}
+                  </div>
+                  <div v-if="event.date">
+                    <v-icon icon="mdi-calendar" class="me-1"/>
+                    {{ event.date }}
+                  </div>
+                  <div v-if="event.start || event.end">
+                    <v-icon icon="mdi-clock-outline" class="me-1"/>
+                    <span v-if="event.start && event.end">
+                      {{ event.start }} – {{ event.end }}
+                    </span>
+                    <span v-else-if="event.start">
+                      Starts at {{ event.start }}
+                    </span>
+                    <span v-else-if="event.end">
+                      Until {{ event.end }}
+                    </span>
+                  </div>
+                </v-card-subtitle>
+                <v-card-text>
+                  <p v-if="event.description" class="mb-4">
+                    {{ event.description }}
+                  </p>
+
+                  <div v-if="event.policies && event.policies.length">
+                    <p class="mb-2">
+                      You qualify via the following policy
+                      {{ event.policies.length === 1 ? "ID" : "IDs" }}:
+                    </p>
+                    <v-chip-group column>
+                      <v-chip
+                        v-for="policy in event.policies"
+                        :key="policy.hash"
+                        color="primary"
+                        variant="outlined"
+                        class="mb-1"
+                      >
+                        {{ policy.name || policy.hash }}
+                      </v-chip>
+                    </v-chip-group>
+                  </div>
+                </v-card-text>
+                <v-card-actions>
+                  <v-btn
+                    color="primary"
+                    variant="text"
+                    :href="route('event.show', event.uuid)"
+                  >
+                    View Event
+                  </v-btn>
+                </v-card-actions>
+              </v-card>
+            </v-col>
+          </v-row>
+        </template>
+
+        <v-alert
+          v-else
+          type="info"
+          class="mt-4"
+        >
+          <template v-if="allEvents.length">
+            No matching public events were found for the assets in your wallet.
+            Try again later or connect a different wallet.
+          </template>
+          <template v-else>
+            There are currently no public upcoming events configured in
+            GateKeeper.
+          </template>
+        </v-alert>
+      </template>
+
+      <template v-else-if="!cardano.loading && cardano.connected === null">
+        <v-alert type="info">
+          Connect a compatible Cardano wallet to discover eligible events.
+        </v-alert>
+      </template>
+    </v-container>
+
+    <!-- Connect Wallet Dialog -->
+    <v-dialog v-model="modal.connectWallet" persistent scrollable
+              max-width="512">
+      <v-card>
+        <v-card-title class="d-flex align-center">
+          Connect Wallet
+          <v-spacer/>
+          <v-btn icon="mdi-close" @click="modal.connectWallet = false"/>
+        </v-card-title>
+        <v-card-text>
+          <v-btn
+            :loading="wallet.busy"
+            block
+            v-for="wallet in cardano.wallets"
+            :key="wallet.name"
+            class="mb-2"
+            size="large"
+            color="primary"
+            @click="connect(wallet)"
+          >
+            <v-avatar size="24" class="me-2">
+              <v-img :src="wallet.icon"/>
+            </v-avatar>
+            {{ format_wallet_name(wallet) }}
+          </v-btn>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
+
+    <!-- Local snackbar for API / wallet errors -->
+    <v-snackbar
+      v-model="snackbar.show"
+      :color="snackbar.color"
+      :timeout="snackbar.timeout"
+      location="top end"
+      variant="elevated"
+    >
+      <div class="d-flex align-center justify-space-between ga-4">
+        <span>{{ snackbar.message }}</span>
+
+        <v-btn
+          icon="mdi-close"
+          size="small"
+          variant="text"
+          @click="snackbar.show = false"
+        />
+      </div>
+    </v-snackbar>
+  </GuestLayout>
+</template>
+<style>
+header.discover-header {
+  color: white;
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.3)),
+  v-bind('bg_image'),
+  linear-gradient(rgba(114, 76, 195, 1.0),
+    rgba(114, 76, 195, 1.0)) center center;
+  background-size: cover;
+
+}
+</style>

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -3,182 +3,241 @@ import {Head} from '@inertiajs/vue3';
 import AppHeader from "@/Components/AppHeader.vue";
 import HowItWorksBg from "@/media/how_it_works.svg"
 import {ref} from "vue";
+import NetworkNotice from "@/Components/NetworkNotice.vue";
 
 defineProps({
-    canLogin: {
-        type: Boolean,
-    },
-    canRegister: {
-        type: Boolean,
-    },
-    laravelVersion: {
-        type: String,
-        required: true,
-    },
-    phpVersion: {
-        type: String,
-        required: true,
-    },
+  canLogin: {
+    type: Boolean,
+  },
+  canRegister: {
+    type: Boolean,
+  }
 });
 
 const how_it_works_bg = ref('url(' + HowItWorksBg + ')');
 </script>
 <template>
-    <Head title="Welcome"/>
-    <v-app class="d-flex">
-        <AppHeader :can-login="canLogin" :can-register="canRegister"></AppHeader>
-        <v-main class="flex-fill">
-            <v-parallax src="https://picsum.photos/2048/1080" height="300" class="hero">
-                <v-container class="d-flex flex-column fill-height justify-center align-center text-white">
-                    <h2>
-                        Convert your Cardano NFTs into
-                        <br/>
-                        tickets to real-world events
-                    </h2>
-                </v-container>
-            </v-parallax>
-            <div id="how-it-works" class="py-16">
-                <v-container class="d-flex flex-column fill-height justify-center align-center">
-                    <h2 class="pb-16">How It Works</h2>
-                    <v-row justify="center" align="stretch">
-                        <v-col cols="8" md="4">
-                            <v-card class="text-center fill-height">
-                                <v-card-title>
-                                    <v-btn color="#C5CAFF" icon size="x-large">
-                                        <v-icon size="x-large" icon="mdi-wallet"></v-icon>
-                                    </v-btn>
-                                </v-card-title>
-                                <v-card-title>Connect Wallet</v-card-title>
-                                <v-card-text class="flex">
-                                    And get access to the dashboard to see available events
-                                </v-card-text>
-                            </v-card>
-                        </v-col>
-                        <v-col cols="8" md="4">
-                            <v-card class="text-center fill-height">
-                                <v-card-title>
-                                    <v-btn color="#C5CAFF" icon size="x-large">
-                                        <v-icon size="x-large" icon="mdi-ticket"></v-icon>
-                                    </v-btn>
-                                </v-card-title>
-                                <v-card-title>Generate Tickets</v-card-title>
-                                <v-card-text class="flex-fill">
-                                    Turn your eligible NFTs into QR code
-                                </v-card-text>
-                            </v-card>
-                        </v-col>
-                        <v-col cols="8" md="4">
-                            <v-card class="text-center fill-height">
-                                <v-card-title>
-                                    <v-btn color="#C5CAFF" icon size="x-large">
-                                        <v-icon size="x-large" icon="mdi-party-popper"></v-icon>
-                                    </v-btn>
-                                </v-card-title>
-                                <v-card-title>Attend Event</v-card-title>
-                                <v-card-text class="flex">
-                                    Show QR code at the entrance and have fun!
-                                </v-card-text>
-                            </v-card>
-                        </v-col>
-                    </v-row>
-                </v-container>
-            </div>
-            <div id="faqs" class="py-16">
-                <v-container class="text-center">
-                    <h2>Frequently Asked Questions</h2>
-                    <v-expansion-panels class="my-16">
-                        <v-expansion-panel>
-                            <v-expansion-panel-title>
-                                What happens if I lose my QR code?
-                                <template v-slot:actions="{expanded}">
-                                    <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
-                                </template>
-                            </v-expansion-panel-title>
-                            <v-expansion-panel-text class="text-start">
-                                If you misplace your QR code it's not a problem! Simply return to this page and generate
-                                a new Ticket QR for your NFT!
-                            </v-expansion-panel-text>
-                        </v-expansion-panel>
-                        <v-expansion-panel>
-                            <v-expansion-panel-title>
-                                How many times can I use a QR code?
-                                <template v-slot:actions="{expanded}">
-                                    <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
-                                </template>
-                            </v-expansion-panel-title>
-                            <v-expansion-panel-text class="text-start"></v-expansion-panel-text>
-                        </v-expansion-panel>
-                        <v-expansion-panel>
-                            <v-expansion-panel-title>
-                                What if I transfer my NFTs?
-                                <template v-slot:actions="{expanded}">
-                                    <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
-                                </template>
-                            </v-expansion-panel-title>
-                            <v-expansion-panel-text class="text-start"></v-expansion-panel-text>
-                        </v-expansion-panel>
-                        <v-expansion-panel>
-                            <v-expansion-panel-title>
-                                Do I have to sign anything in my wallet to get access to the dashboard?
-                                <template v-slot:actions="{expanded}">
-                                    <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
-                                </template>
-                            </v-expansion-panel-title>
-                            <v-expansion-panel-text class="text-start"></v-expansion-panel-text>
-                        </v-expansion-panel>
-                    </v-expansion-panels>
-                </v-container>
-            </div>
-        </v-main>
-        <v-footer color="primary" class="flex-0-1">
-            <v-row justify="center">
-                <v-col cols="12" class="text-center">
-                    <p>
-                        Powered by <strong>GateKeeper OSS</strong> (
-                        <a href="https://github.com/CardanoGateKeeper/Core" target="_blank">
-                            View on GitHub
-                            <v-icon icon="mdi-github"></v-icon>
-                        </a>
-                        )
-                    </p>
-                    <p>
-                        An open source project created by Adam K. Dean &amp; Latheesan Kanesamoorthy
-                        <br/>
-                        Maintained by the Cardano community with
-                        <v-icon icon="mdi-heart" class="" title="Love"></v-icon>
-                    </p>
-                </v-col>
-            </v-row>
-        </v-footer>
-    </v-app>
+  <Head title="Welcome"/>
+  <v-app class="d-flex">
+    <NetworkNotice />
+    <v-main class="flex-fill">
+      <v-parallax src="https://picsum.photos/2048/1080" height="300"
+                  class="hero">
+        <AppHeader :can-login="canLogin"
+                   :can-register="canRegister"></AppHeader>
+        <v-container
+          class="d-flex flex-column fill-height justify-center align-center text-white">
+          <h2>
+            Convert your Cardano NFTs into
+            <br/>
+            tickets to real-world events
+          </h2>
+        </v-container>
+      </v-parallax>
+      <div id="how-it-works" class="py-16">
+        <v-container
+          class="d-flex flex-column fill-height justify-center align-center">
+          <h2 class="pb-16">How It Works</h2>
+          <v-row justify="center" align="stretch">
+            <v-col cols="8" md="4">
+              <v-card class="text-center fill-height"
+                      :href="route('events.discover')">
+                <v-card-title>
+                  <v-btn color="#C5CAFF" icon size="x-large">
+                    <v-icon size="x-large" icon="mdi-wallet"></v-icon>
+                  </v-btn>
+                </v-card-title>
+                <v-card-title>Connect Wallet</v-card-title>
+                <v-card-text class="flex">
+                  And get access to the dashboard to see available events
+                </v-card-text>
+              </v-card>
+            </v-col>
+            <v-col cols="8" md="4">
+              <v-card class="text-center fill-height"
+                      :href="route('events.discover')">
+                <v-card-title>
+                  <v-btn color="#C5CAFF" icon size="x-large">
+                    <v-icon size="x-large" icon="mdi-ticket"></v-icon>
+                  </v-btn>
+                </v-card-title>
+                <v-card-title>Generate Tickets</v-card-title>
+                <v-card-text class="flex-fill">
+                  Turn your eligible NFTs into QR code
+                </v-card-text>
+              </v-card>
+            </v-col>
+            <v-col cols="8" md="4">
+              <v-card class="text-center fill-height"
+                      :href="route('events.discover')">
+                <v-card-title>
+                  <v-btn color="#C5CAFF" icon size="x-large">
+                    <v-icon size="x-large" icon="mdi-party-popper"></v-icon>
+                  </v-btn>
+                </v-card-title>
+                <v-card-title>Attend Event</v-card-title>
+                <v-card-text class="flex">
+                  Show QR code at the entrance and have fun!
+                </v-card-text>
+              </v-card>
+            </v-col>
+          </v-row>
+        </v-container>
+      </div>
+      <div id="faqs" class="py-16">
+        <v-container class="text-center">
+          <h2>Frequently Asked Questions</h2>
+          <v-expansion-panels class="my-16">
+            <v-expansion-panel>
+              <v-expansion-panel-title>
+                What happens if I lose my QR code?
+                <template v-slot:actions="{expanded}">
+                  <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
+                </template>
+              </v-expansion-panel-title>
+              <v-expansion-panel-text class="text-start">
+                <p class="mb-2">Each ticket QR code can be regenerated at any
+                  time.</p>
+                <p class="mb-2">As long as you still hold the qualifying NFT in
+                  your wallet, you
+                  can simply reconnect your wallet on the event page and
+                  generate
+                  a new QR code instantly. The system does not store your QR
+                  image
+                  — it recreates it on demand using your wallet’s current NFT
+                  ownership and your signature.</p>
+                <p class="mb-2">If you lose your code, just return to the event
+                  page, connect
+                  your wallet, and generate a fresh ticket.</p>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+            <v-expansion-panel>
+              <v-expansion-panel-title>
+                How many times can I use a QR code?
+                <template v-slot:actions="{expanded}">
+                  <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
+                </template>
+              </v-expansion-panel-title>
+              <v-expansion-panel-text
+                class="text-start">
+                <p class="mb-2">Each QR code can be scanned only once for
+                  entry.</p>
+                <p class="mb-2">After it is scanned at the venue, GateKeeper
+                  marks the ticket as used, and it cannot be reused — even if
+                  someone copies or screenshots your QR.</p>
+                <p class="mb-2">If you haven’t scanned it yet, you may
+                  regenerate the QR code as many times as you want, but only the
+                  first valid scan will be accepted at the event.</p>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+            <v-expansion-panel>
+              <v-expansion-panel-title>
+                What if I transfer my NFTs?
+                <template v-slot:actions="{expanded}">
+                  <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
+                </template>
+              </v-expansion-panel-title>
+              <v-expansion-panel-text
+                class="text-start">
+                <p class="mb-2">Ticket access is based on current ownership, not
+                  past ownership.</p>
+                <p class="mb-2">If you transfer your NFT to someone else before
+                  generating or scanning your ticket, you lose the ability to
+                  create a valid ticket.</p>
+                <p class="mb-2">If you already generated a QR code but transfer
+                  the NFT afterward, the system will detect that you no longer
+                  own the asset and the ticket will become invalid at the
+                  door.</p>
+                <p class="mb-2">In short:</p>
+                <ul class="mb-2 ml-8">
+                  <li>Ownership at the moment of entry is what matters</li>
+                  <li>Transferring the NFT transfers the right to generate a
+                    new ticket
+                  </li>
+                </ul>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+            <v-expansion-panel>
+              <v-expansion-panel-title>
+                Do I have to sign anything in my wallet to get access to the
+                dashboard?
+                <template v-slot:actions="{expanded}">
+                  <v-icon :icon="expanded ? 'mdi-close' : 'mdi-plus'"/>
+                </template>
+              </v-expansion-panel-title>
+              <v-expansion-panel-text
+                class="text-start">
+                <p class="mb-2">No — you will <b>never</b> be asked to sign
+                  anything for dashboard access.</p>
+                <p class="mb-2">The dashboard is for event organizers and
+                  internal GateKeeper functions, not attendees.</p>
+                <p class="mb-2">Attendees only need to:</p>
+                <ol class="ml-8 mb-2">
+                  <li>Connect their wallet using CIP-30</li>
+
+                  <li>Sign a one-time message when generating a ticket</li>
+                </ol>
+                <p class="mb-2">You will <b>never</b> be prompted to sign
+                  transactions or authorize spending.</p>
+                <p class="mb-2">GateKeeper only asks for a lightweight signature
+                  used to verify NFT ownership — nothing more.</p>
+
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+          </v-expansion-panels>
+        </v-container>
+      </div>
+    </v-main>
+    <v-footer color="primary" class="flex-0-1">
+      <v-row justify="center">
+        <v-col cols="12" class="text-center">
+          <p>
+            Powered by <strong>GateKeeper OSS</strong> (
+            <a href="https://github.com/CardanoGateKeeper/Core" target="_blank">
+              View on GitHub
+              <v-icon icon="mdi-github"></v-icon>
+            </a>
+            )
+          </p>
+          <p>
+            An open source project created by Adam K. Dean &amp; Latheesan
+            Kanesamoorthy
+            <br/>
+            Maintained by the Cardano community with
+            <v-icon icon="mdi-heart" class="" title="Love"></v-icon>
+          </p>
+        </v-col>
+      </v-row>
+    </v-footer>
+  </v-app>
 </template>
 <style>
 .v-footer a {
-    color: inherit !important
+  color: inherit !important
 }
 
 h1, h2, h3, h4, h5 {
-    font-family: Lexend, 'Open Sans', sans-serif;
+  font-family: Lexend, 'Open Sans', sans-serif;
 }
 
 h2 {
-    font-size: 34px;
+  font-size: 34px;
 }
 
 .v-parallax.hero .v-responsive__content {
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0.75) 0%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(to right, rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0.3)), linear-gradient(rgba(114, 76, 195, 1.0),
+  rgba(114, 76, 195, 1.0)) center center;
 }
 
 #how-it-works {
-    background: v-bind(how_it_works_bg) center center;
-    background-size: cover;
-    border-bottom: 1px solid rgba(238, 229, 255, 0.5);
-    /*border-bottom: 1px solid rgba(var(--v-theme-primary), 0.25);*/
-    border-top: 1px solid rgba(238, 229, 255, 0.5);
+  background: v-bind(how_it_works_bg) center center;
+  background-size: cover;
+  border-bottom: 1px solid rgba(238, 229, 255, 0.5);
+  border-top: 1px solid rgba(238, 229, 255, 0.5);
 }
 
 #how-it-works .v-card {
-    border-bottom-color: rgb(var(--v-theme-primary));
-    border-bottom-width: 4px;
+  border-bottom-color: rgb(var(--v-theme-primary));
+  border-bottom-width: 4px;
 }
 </style>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,24 +1,28 @@
 <?php
 
-  use Illuminate\Http\Request;
-  use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\EventController;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 
-  /*
-  |--------------------------------------------------------------------------
-  | API Routes
-  |--------------------------------------------------------------------------
-  |
-  | Here is where you can register API routes for your application. These
-  | routes are loaded by the RouteServiceProvider and all of them will
-  | be assigned to the "api" middleware group. Make something great!
-  |
-  */
+/*
+|--------------------------------------------------------------------------
+| API Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register API routes for your application. These
+| routes are loaded by the RouteServiceProvider and all of them will
+| be assigned to the "api" middleware group. Make something great!
+|
+*/
 
-  Route::get('/teapot', static function (Request $request) {
-    exit(config('app.nftcdn_domain'));
+Route::middleware('throttle:30,1')->group(function () {
+  Route::get('/events/discover', [EventController::class, 'index'])
+    ->name('api.events.discover');
+  Route::get('/events/discover/policy/{policyHash}', [EventController::class, 'byPolicy'])
+    ->name('api.events.by-policy');
+})->middleware('cache.headers:public;max_age=60;etag');
+
+Route::middleware('auth:sanctum')
+  ->get('/user', static function (Request $request) {
+    return $request->user();
   });
-
-  Route::middleware('auth:sanctum')
-       ->get('/user', static function (Request $request) {
-         return $request->user();
-       });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,66 +1,68 @@
 <?php
 
-  use App\Http\Controllers\CheckinController;
-  use App\Http\Controllers\CheckoutController;
-  use App\Http\Controllers\EventAdminController;
-  use App\Http\Controllers\EventCheckinController;
-  use App\Http\Controllers\EventController;
-  use App\Http\Controllers\EventPolicyController;
-  use App\Http\Controllers\ImageController;
-  use App\Http\Controllers\TeamPolicyController;
-  use App\Http\Controllers\TicketController;
-  use Illuminate\Foundation\Application;
-  use Illuminate\Http\Request;
-  use Illuminate\Support\Facades\Route;
-  use Inertia\Inertia;
+use App\Http\Controllers\CheckinController;
+use App\Http\Controllers\CheckoutController;
+use App\Http\Controllers\EventAdminController;
+use App\Http\Controllers\EventCheckinController;
+use App\Http\Controllers\EventController;
+use App\Http\Controllers\EventPolicyController;
+use App\Http\Controllers\ImageController;
+use App\Http\Controllers\TeamPolicyController;
+use App\Http\Controllers\TicketController;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
 
 
-  /*
-  |--------------------------------------------------------------------------
-  | Web Routes
-  |--------------------------------------------------------------------------
-  |
-  | Here is where you can register web routes for your application. These
-  | routes are loaded by the RouteServiceProvider within a group which
-  | contains the "web" middleware group. Now create something great!
-  |
-  */
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
 
-  Route::get('/', static function () {
-    return Inertia::render('Welcome', [
-      'canLogin' => Route::has('login'),
-      'canRegister' => Route::has('register'),
-      'laravelVersion' => Application::VERSION,
-      'phpVersion' => PHP_VERSION,
-    ]);
+Route::get('/', static function () {
+  return Inertia::render('Welcome', [
+    'canLogin' => Route::has('login'),
+    'canRegister' => Route::has('register'),
+    'laravelVersion' => Application::VERSION,
+    'phpVersion' => PHP_VERSION,
+  ]);
+})->name('home');
+
+Route::resource('event', EventController::class);
+Route::get('/discover-events', [EventController::class, 'discoverPage'])
+  ->name('events.discover');
+Route::resource('ticket', TicketController::class);
+Route::get('image/{asset_key}', [ImageController::class, 'show'])
+  ->name('image.show');
+
+Route::middleware([
+  'auth:sanctum',
+  config('jetstream.auth_session'),
+  'verified',
+])
+  ->group(static function () {
+    Route::get('/dashboard', static function (Request $request) {
+      return Inertia::render('Dashboard');
+    })
+      ->name('dashboard');
+
+    Route::resource('scan-tickets', EventCheckinController::class);
+    Route::resource('event.check-in', CheckinController::class);
+    Route::resource('event.check-out', CheckoutController::class);
+    Route::resource('manage-event', EventAdminController::class);
+
+    Route::resource('team.policy', TeamPolicyController::class)
+      ->shallow()
+      ->names([
+        'show' => 'team.policy.show'
+      ]);
+    Route::resource('event.policy', EventPolicyController::class);
   });
-
-  Route::resource('event', EventController::class);
-  Route::resource('ticket', TicketController::class);
-  Route::get('image/{asset_key}', [ImageController::class, 'show'])
-       ->name('image.show');
-
-  Route::middleware([
-    'auth:sanctum',
-    config('jetstream.auth_session'),
-    'verified',
-  ])
-       ->group(static function () {
-         Route::get('/dashboard', static function (Request $request) {
-           return Inertia::render('Dashboard');
-         })
-              ->name('dashboard');
-
-         Route::resource('scan-tickets', EventCheckinController::class);
-         Route::resource('event.check-in', CheckinController::class);
-         Route::resource('event.check-out', CheckoutController::class);
-         Route::resource('manage-event', EventAdminController::class);
-
-         Route::resource('team.policy', TeamPolicyController::class)
-              ->shallow()
-              ->names([
-                'show' => 'team.policy.show'
-              ]);
-         Route::resource('event.policy', EventPolicyController::class);
-       });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,23 +3,26 @@ import laravel from 'laravel-vite-plugin';
 import vue from '@vitejs/plugin-vue';
 
 export default defineConfig({
-    server: {
-        hmr: {
-            host: '10.1.1.11'
-        }
+  server: {
+    host: '0.0.0.0',   // listen on all interfaces *inside* the container
+    port: 5173,        // optional; matches your docker-compose command
+    hmr: {
+      host: 'localhost', // what the BROWSER uses to reach Vite
+      port: 5173,
     },
-    plugins: [
-        laravel({
-            input: 'resources/js/app.js',
-            refresh: true,
-        }),
-        vue({
-            template: {
-                transformAssetUrls: {
-                    base: null,
-                    includeAbsolute: false,
-                },
-            },
-        }),
-    ],
+  },
+  plugins: [
+    laravel({
+      input: 'resources/js/app.js',
+      refresh: true,
+    }),
+    vue({
+      template: {
+        transformAssetUrls: {
+          base: null,
+          includeAbsolute: false,
+        },
+      },
+    }),
+  ],
 });


### PR DESCRIPTION
- Added API Endpoint for returning all public events
- Added API Endpoint for returning public events for a specified Policy ID
- Added a rate limiting throttle of 30 requests per minute as a sensible default
- Updates to the app header bar to make it more consistent across pages
- Add network notice when browsing preprod deployment alerting users to nightly data reset
- Add Laravel Scribe for generating API documentation
- Add demo database seeder to create some simulated events and tickets in preprod/local environment for testing layout and UI/UX behavior more reliably
- Add "Discover Events" page where users can connect their wallet and find all public events they are eligible for
- Updates to Docker Compose file to also run the vite development server when using sail for local development
- Add Scribe annotations for public API endpoints
- Make some features of Fortify like password changing and registration controllable via environment variables so we can keep have different features based on preprod or production
- Schedule preprod environments to reset nightly at 00:00 UTC
- Add snackbar to the public events page so we can show better error messaging to the user