### PR TITLE
Change to PHP 8.3 like the regular deployment scripts so the lock fil…

### DIFF
--- a/.github/workflows/publish-api.yml
+++ b/.github/workflows/publish-api.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: 8.3
+          tools: composer:v2
+          coverage: none
 
       - name: Install dependencies
         run: composer install --no-interaction --no-progress --prefer-dist


### PR DESCRIPTION
…es don't throw errors during job run.